### PR TITLE
Fixing stuff, updating stuff, tryin' to help

### DIFF
--- a/VSVillage/assets/vsvillage/config/activitycollections/working-villager.json
+++ b/VSVillage/assets/vsvillage/config/activitycollections/working-villager.json
@@ -47,208 +47,40 @@
             {
               "$type": "Vintagestory.GameContent.StandardAIAction, VSSurvivalMod",
               "durationSeconds": 60.0
-            }
+            },
+         {
+            "$type": "Vintagestory.GameContent.UnequipAction, VSSurvivalMod",
+            "Target": "righthand"
+         }
           ]
         },
         "ConditionsOp": 1
       },
-      {
-        "$type": "Vintagestory.GameContent.EntityActivity, VSSurvivalMod",
-        "Slot": 0,
-        "Priority": 20.0,
-        "Name": "notaggressive",
-        "Code": "notaggressive",
-        "Conditions": {
-          "$type": "Vintagestory.GameContent.IActionCondition[], VSSurvivalMod",
-          "$values": [
-            {
-              "$type": "Vintagestory.GameContent.EmotionStateCondition, VSSurvivalMod",
-              "emotionState": "aggressiveondamage",
-              "Invert": true
+
+
+
+         {
+            "$type": "Vintagestory.GameContent.EntityActivity, VSSurvivalMod",
+            "Slot": 15,
+            "Priority": 1,
+            "Name": "allowaitasks",
+            "Code": "allowaitasks",
+            "Conditions": {
+               "$type": "Vintagestory.GameContent.IActionCondition[], VSSurvivalMod",
+               "$values": []
             },
-            {
-              "$type": "Vintagestory.GameContent.HeldCondition, VSSurvivalMod",
-              "Code": "game:spear-generic-blackbronze",
-              "Invert": false
+            "Actions": {
+               "$type": "Vintagestory.GameContent.IEntityAction[], VSSurvivalMod",
+               "$values": [
+                  {
+                     "$type": "Vintagestory.GameContent.StandardAIAction, VSSurvivalMod",
+                     "durationSeconds": 99999999
+                  }
+               ]
             },
-            {
-              "$type": "Vintagestory.GameContent.TemporalStormCondition, VSSurvivalMod",
-              "Invert": true
-            }
-          ]
-        },
-        "Actions": {
-          "$type": "Vintagestory.GameContent.IEntityAction[], VSSurvivalMod",
-          "$values": [
-            {
-              "$type": "Vintagestory.GameContent.UnequipAction, VSSurvivalMod",
-              "Target": "righthand"
-            }
-          ]
-        },
-        "ConditionsOp": 1
-      },
-      {
-        "$type": "Vintagestory.GameContent.EntityActivity, VSSurvivalMod",
-        "Slot": 0,
-        "Priority": 1.0,
-        "Name": "GotoWork",
-        "Code": "GotoWork",
-        "Conditions": {
-          "$type": "Vintagestory.GameContent.IActionCondition[], VSSurvivalMod",
-          "$values": [
-            {
-              "$type": "Vintagestory.GameContent.TimeOfDayCondition, VSSurvivalMod",
-              "minHour": 7.0,
-              "maxHour": 16.0,
-              "Invert": false
-            },
-            {
-              "$type": "VsVillage.CloseToPointOfInterestCondition, vsvillage",
-              "Invert": true,
-              "Target": 1,
-              "MaxDistance": 6.0
-            }
-          ]
-        },
-        "Actions": {
-          "$type": "Vintagestory.GameContent.IEntityAction[], VSSurvivalMod",
-          "$values": [
-            {
-              "$type": "VsVillage.GotoPointOfInterestAction, vsvillage",
-              "Target": 1,
-              "AnimSpeed": 1.0,
-              "WalkSpeed": 0.02,
-              "AnimCode": "walk"
-            }
-          ]
-        },
-        "ConditionsOp": 1
-      },
-      {
-        "$type": "Vintagestory.GameContent.EntityActivity, VSSurvivalMod",
-        "Slot": 0,
-        "Priority": 1.0,
-        "Name": "GotoBed",
-        "Code": "GotoBed",
-        "Conditions": {
-          "$type": "Vintagestory.GameContent.IActionCondition[], VSSurvivalMod",
-          "$values": [
-            {
-              "$type": "Vintagestory.GameContent.TimeOfDayCondition, VSSurvivalMod",
-              "minHour": 22.0,
-              "maxHour": 6.0,
-              "Invert": false
-            },
-            {
-              "$type": "VsVillage.CloseToPointOfInterestCondition, vsvillage",
-              "Invert": true,
-              "Target": 0,
-              "MaxDistance": 2.0
-            }
-          ]
-        },
-        "Actions": {
-          "$type": "Vintagestory.GameContent.IEntityAction[], VSSurvivalMod",
-          "$values": [
-            {
-              "$type": "VsVillage.ToggleBrazierFireAction, vsvillage",
-              "MaxDistance": 3.0,
-              "Ignite": false
-            },
-            {
-              "$type": "VsVillage.GotoPointOfInterestAction, vsvillage",
-              "Target": 0,
-              "AnimSpeed": 1.0,
-              "WalkSpeed": 0.02,
-              "AnimCode": "walk"
-            }
-          ]
-        },
-        "ConditionsOp": 1
-      },
-      {
-        "$type": "Vintagestory.GameContent.EntityActivity, VSSurvivalMod",
-        "Slot": 0,
-        "Priority": 1.0,
-        "Name": "GotoGatherplace",
-        "Code": "GotoGatherplace",
-        "Conditions": {
-          "$type": "Vintagestory.GameContent.IActionCondition[], VSSurvivalMod",
-          "$values": [
-            {
-              "$type": "Vintagestory.GameContent.TimeOfDayCondition, VSSurvivalMod",
-              "minHour": 18.0,
-              "maxHour": 21.0,
-              "Invert": false
-            },
-            {
-              "$type": "VsVillage.CloseToPointOfInterestCondition, vsvillage",
-              "Invert": true,
-              "Target": 2,
-              "MaxDistance": 6.0
-            }
-          ]
-        },
-        "Actions": {
-          "$type": "Vintagestory.GameContent.IEntityAction[], VSSurvivalMod",
-          "$values": [
-            {
-              "$type": "VsVillage.GotoPointOfInterestAction, vsvillage",
-              "Target": 2,
-              "AnimSpeed": 1.0,
-              "WalkSpeed": 0.02,
-              "AnimCode": "walk"
-            },
-            {
-              "$type": "VsVillage.ToggleBrazierFireAction, vsvillage",
-              "MaxDistance": 3.0,
-              "Ignite": true
-            }
-          ]
-        },
-        "ConditionsOp": 1
-      },
-      {
-        "$type": "Vintagestory.GameContent.EntityActivity, VSSurvivalMod",
-        "Slot": 0,
-        "Priority": 1.0,
-        "Name": "Sleep",
-        "Code": "Sleep",
-        "Conditions": {
-          "$type": "Vintagestory.GameContent.IActionCondition[], VSSurvivalMod",
-          "$values": [
-            {
-              "$type": "Vintagestory.GameContent.AnimationCondition, VSSurvivalMod",
-              "animCode": "sleep",
-              "Invert": true
-            },
-            {
-              "$type": "Vintagestory.GameContent.TimeOfDayCondition, VSSurvivalMod",
-              "minHour": 22.0,
-              "maxHour": 6.0,
-              "Invert": false
-            },
-            {
-              "$type": "VsVillage.CloseToPointOfInterestCondition, vsvillage",
-              "Invert": false,
-              "Target": 0,
-              "MaxDistance": 3.0
-            }
-          ]
-        },
-        "Actions": {
-          "$type": "Vintagestory.GameContent.IEntityAction[], VSSurvivalMod",
-          "$values": [
-            {
-              "$type": "VsVillage.SleepAction, vsvillage",
-              "AnimSpeed": 1.0,
-              "AnimCode": "Lie"
-            }
-          ]
-        },
-        "ConditionsOp": 1
-      }
+            "ConditionsOp": 1
+         }
     ]
   }
 }
+

--- a/VSVillage/assets/vsvillage/entities/villager.json
+++ b/VSVillage/assets/vsvillage/entities/villager.json
@@ -26,10 +26,10 @@
 					"game:sounds/voice/oboe/"
 				]
 		},
-		"personality": "balanced",
 		"personalities": {
-			"balanced": { "chordDelayMul": 1.3, "pitchModifier": 0.7, "volumneModifier": 1.1 }
-		},
+    "balanced": { "chordDelayMul": 1.3, "pitchModifier": 0.7, "volumneModifier": 1.1 },
+    "elderbalanced": { "chordDelayMul": 1.8, "pitchModifier": 0.6, "volumneModifier": 1.0 }
+},
 		"shouldSwivelFromMotion": false,
         "outfitConfigFileName": "villageraccessories-{sex}",
 		"partialRandomOutfits": 

--- a/VSVillage/assets/vsvillage/entities/villager.json
+++ b/VSVillage/assets/vsvillage/entities/villager.json
@@ -205,7 +205,7 @@
 			{ "code": "villagerinventory" },
 			{ "code": "nametag", "showtagonlywhentargeted": true },
 			{ "code": "repulseagents" },
-			{ "code": "controlledphysics", "stepHeight": 1.01 },
+			{ "code": "controlledphysics", "stepHeight": 1.2 },
 			{ "code": "interpolateposition" },
 			{
 				"code": "Villager",
@@ -652,9 +652,72 @@
 		},
 		"behaviors": [
 			{ "code": "villagerinventory" },
-			{ "code": "nametag", "showtagonlywhentargeted": true, "selectFromRandomNameByType": {"*-male-*": ["Aphid", "Erik", "Adachi", "Farhad", "Pegalesharro", "Floyd", "Temper", "En Repos", "Alanus", "Baldrich", "Cuno", "Dominicus", "Ludwig", "Lambert", "Geralt", "Richard", "Wolfram", "Zachäus", "Pippin", "Frodo", "Baggins", "Rudolf", "Marcus", "Benjamin", "Cronos", "Timoleon", "Leonidas", "Xerxes", "Brutus", "William", "Maurinus", "Hubertus"], "*-female-*": ["Anne", "Agnes", "Adachi", "Farhad", "Bianca", "Hedwig", "Demud", "Imagina", "Johanna", "Judith", "Magdalena", "Philippa", "Methild", "Violante", "Walpurga", "Josephine", "Joana", "Yvonne", "Lisbeth", "Dione", "Diana", "Olivia", "Hermine", "Triss", "Yennefer", "Lucia", "Mirella", "Bernadetta", "Tacia"]}},
+			 {
+  "code": "nametag",
+  "showtagonlywhentargeted": true,
+  "selectFromRandomNameByType": {
+    "*-male-*": [
+      "Aphid", "Erik", "Adachi", "Farhad", "Pegalesharro", "Floyd", "Temper", "En Repos",
+      "Alanus", "Baldrich", "Cuno", "Dominicus", "Ludwig", "Lambert", "Geralt", "Richard",
+      "Wolfram", "Zachäus", "Pippin", "Frodo", "Baggins", "Rudolf", "Marcus", "Benjamin",
+      "Cronos", "Timoleon", "Leonidas", "Xerxes", "Brutus", "William", "Maurinus", "Hubertus",
+
+      "Alaric", "Benedict", "Cassian", "Dorian", "Edric", "Falk", "Gareth", "Hadrian",
+      "Isembard", "Jasper", "Korin", "Lucan", "Matthis", "Nestor", "Osmund", "Percival",
+      "Quentin", "Roland", "Sebastian", "Tobias", "Ulric", "Valerian", "Wystan", "Yorick",
+      "Zephyr", "Cedric", "Drustan", "Erasmus", "Ferdinand", "Gregor", "Henrik", "Julian",
+      "Konrad", "Leopold", "Magnus", "Niklas", "Octavian", "Philipp", "Rainer", "Sigmund",
+      "Theobald", "Viktor", "Wilhelm", "Zeno",
+
+      "Amir", "Hassan", "Yusuf", "Karim", "Rashid", "Jamal", "Nabil", "Faisal", "Khalid",
+      "Omar", "Samir", "Tariq", "Zahir", "Basim", "Idris", "Malik", "Nasir", "Salim",
+      "Hakim", "Farid", "Aziz", "Ibrahim", "Musa", "Ismail", "Suleiman", "Hamza", "Bilal",
+      "Qasim", "Adnan", "Zayed", "Arman", "Reza", "Navid", "Mehrdad", "Kamran", "Parviz",
+
+      "Darius", "Cyrus", "Arash", "Kaveh", "Ramin", "Soroush", "Babak", "Rostam",
+      "Aleksander", "Marek", "Pavel", "Rurik", "Veselin", "Boris", "Ilia", "Mikhail",
+      "Sorin", "Dragomir", "Andrei", "Bogdan", "Nikola",
+
+      "Santiago", "Mateo", "Rafael", "Diego", "Lucio", "Marco", "Enzo", "Paolo", "Gianni",
+      "Alonso", "Esteban", "Hector", "Tomas", "Iker", "Javier"
+    ],
+
+    "*-female-*": [
+      "Anne", "Agnes", "Adachi", "Farhad", "Bianca", "Hedwig", "Demud", "Imagina", "Johanna",
+      "Judith", "Magdalena", "Philippa", "Methild", "Violante", "Walpurga", "Josephine",
+      "Joana", "Yvonne", "Lisbeth", "Dione", "Diana", "Olivia", "Hermine", "Triss",
+      "Yennefer", "Lucia", "Mirella", "Bernadetta", "Tacia",
+
+      "Adelheid", "Beatrix", "Clarissa", "Dorothea", "Elisabet", "Felicity", "Gisela",
+      "Helena", "Isolde", "Juliana", "Katarina", "Leonie", "Maribel", "Nerissa", "Odette",
+      "Petra", "Rosalind", "Sabina", "Theresa", "Ulrika", "Valeria", "Winifred", "Zinnia",
+
+      "Amina", "Layla", "Nadia", "Samira", "Farah", "Zahra", "Mariam", "Yasmin", "Hana",
+      "Rania", "Dalia", "Salma", "Khadija", "Noor", "Iman", "Sahar", "Leila", "Aaliyah",
+      "Amira", "Hiba", "Noura", "Sanaa", "Zainab", "Basira", "Karima", "Latifa",
+
+      "Parisa", "Shirin", "Anahita", "Laleh", "Roxana", "Mitra", "Golnar", "Nasrin",
+      "Soraya", "Yalda",
+
+      "Elena", "Irina", "Svetlana", "Katya", "Milena", "Anya", "Daria", "Vesna", "Zora",
+      "Radka", "Katerina", "Bogdana",
+
+      "Isabella", "Sofia", "Camila", "Valentina", "Marina", "Elisa", "Francesca", "Paola",
+      "Daniela", "Rosa", "Luciana", "Teresa", "Ines", "Pilar", "Alma"
+    ]
+  }
+},
+
+{
+				"code": "activitydriven",
+				"activityCollectionPathByType": {
+					"*": "working-villager"
+				}
+			},
+
 			{ "code": "repulseagents" },
-			{ "code": "controlledphysics", "stepHeight": 1.01 },
+                        { "code": "safeonhurt" },
+			{ "code": "controlledphysics", "stepHeight": 1.2 },
 			{ "code": "health", "currenthealthByType": {"*-smith": 30, "*-soldier": 40, "*": 20 }, "maxhealthByType": {"*-smith": 30, "*-soldier": 40, "*": 20}},
 			{
 				"code": "emotionstates",
@@ -668,93 +731,213 @@
                 "hoursToDecay": 96,
                 "decayedBlock": "drycarcass-humanoid1"
             },
-            {
-				"code": "activitydriven",
-				"activityCollectionPathByType": {
-					"*": "working-villager"
-				}
+
+{
+	"code": "taskai",
+	"aitasks": [
+		{
+			"code": "villagermeleeattack",
+			"entityCodes": ["bandit-*", "lonehuntergoblin-*", "ork-*", "surfacegoblin-*", "drifter-*", "shiver-*", "bowtorn-*", "direwolf-male", "direwolf-female", "hellboar-male", "hellboar-female","bear-*", "wolf-male", "wolf-female"],
+			"priority": 2,
+			"damageByType": { "*-soldier": 12, "*-archer": 6, "*": 4 },
+			"damageTierByType":{ "*-soldier": 2, "*-archer": 2, "*": 0},
+			"mincooldown": 1500,
+			"maxcooldown": 2500,
+			"attackDurationMs": 900,
+			"animationByType": { "*-archer": "BowAim", "*": "Attack" },
+			"stabanimation": "SpearStab",
+			"stabanimationspeed": 0.7,
+			"slashanimation": "SwordHit",
+			"slashanimationspeed": 0.7,
+			"animationSpeedByType": { "*-archer": 1, "*":  2 },
+			"durationMs": 1300,
+			"releaseAtMs": 1000,
+			"seekingRange": 25,
+			"animationRelase": "BowHit",
+			"drawingsound": "game:sounds/bow-draw.ogg",
+			"shootingsound": "game:sounds/bow-release.ogg",
+			"projectile": "game:arrow-iron"
+		},
+		{
+			"code": "seekentity",
+			"entityCodesByType": {
+				"*-soldier": ["bandit-*", "lonehuntergoblin-*", "ork-*", "surfacegoblin-*", "drifter-*", "shiver-*", "bowtorn-*", "direwolf-male", "direwolf-female", "hellboar-male", "hellboar-female","bear-*", "wolf-male", "wolf-female"],
+				"*": ["bandit-*", "surfacegoblin-*", "wolf-male", "wolf-female"]
 			},
-			{
-				"code": "taskai",
-				"aitasks": [
-					{
-						"code": "meleeattack",
-						"entityCodes": ["player"],
-						"priority": 2,
-						"damage": 5,
-						"mincooldown": 2500,
-						"maxcooldown": 3500,
-						"attackDurationMs": 900,
-						"damagePlayerAtMs": 300,
-						"animation": "spear-attack",
-						"animationSpeed": 2,
-						"whenInEmotionState": "aggressiveondamage"
-					},
-					{
-						"code": "seekentity",
-						"entityCodes": ["player"],
-						"priority": 1.5,
-						"mincooldown": 1000,
-						"maxcooldown": 1500,
-						"seekingRange": 20,
-						"movespeed": 0.035,
-						"animation": "Run",
-						"animationSpeed": 1.75,
-						"whenInEmotionState": "aggressiveondamage"
-					},
-					{
-						"code": "fleeentity",
-						"entityCodes": ["player"],
-						"priority": 1.5,
-						"movespeed": 0.035,
-						"seekingRange": 12,
-						"animation": "Run",
-						"animationSpeed": 1.75,
-						"whenInEmotionState": "fleeondamage"
-					},
-					{
-						"code": "fleeentity",
-						"entityCodes": ["drifter-*", "shiver-*", "bowtorn-*"],
-						"priority": 1.49,
-						"movespeed": 0.035,
-						"seekingRange": 6,
-						"animation": "Run",
-						"animationSpeed": 1.75
-					},
-					{
-						"code": "idle",
-						"priority": 1.2,
-						"minduration": 2500,
-						"maxduration": 2500,
-						"mincooldown": 2000,
-						"maxcooldown": 10000,
-						"animation": "laugh"
-					},
-					{
-						"code": "idle",
-						"priority": 1.2,
-						"minduration": 2500,
-						"maxduration": 2500,
-						"mincooldown": 5000,
-						"maxcooldown": 30000,
-						"animation": "idle2"
-					},
-					{
-						"code": "wander",
-						"priority": 1.0,
-						"movespeed": 0.01,
-						"animation": "Walk",
-						"wanderChance": 0.005,
-						"maxDistanceToSpawn": 15,
-						"wanderRangeMin": 1,
-						"wanderRangeMax": 3
-					},
-					{
-						"code": "lookaround",
-						"priority": 0.5
-					}
-				]
+			"priority": 5,
+			"mincooldown": 1000,
+			"maxcooldown": 1500,
+			"seekingRange": 12,
+			"minRangeByType": { "*-archer": 8, "*": 0 },
+			"movespeed": 0.008,
+			"animation": "Run",
+			"animationSpeed": 1.75
+		},
+		{
+			"code": "fleeentity",
+			"entityCodesByType": {
+				"*-soldier": [],
+				"*": ["drifter-*", "locust-*", "shiver-*", "bowtorn-*", "bear-*", "wolf-male", "wolf-female", "ork-*", "direwolf-*", "hellboar-*", "bear-*"]
 			},
+			"priority": 10,
+			"movespeed": 0.008,
+			"seekingRange": 4,
+                        "animation": "Run",
+			"animationByType": { "*-archer": "Run", "*-soldier": "Run", "*": "Run" },
+			"animationSpeed": 1.75
+		},
+		{
+			"code": "villagersleep",
+			"priority": 9.0,
+			"movespeed": 0.008,
+			"animation": "Walk",
+			"duringDayTimeFrames": [ { "fromHour": 21.5, "toHour": 6 }],
+			"mincooldown": 5000,
+			"maxcooldown": 10000
+		},
+		{
+			"code": "villagerhealwounded",
+			"slot": 1,
+			"minduration": 5000,
+			"maxduration": 8000,
+			"mincooldown": 45000,
+			"maxcooldown": 90000,
+			"maxdistance": 15,
+			"animation": "walk",
+			"animationSpeed": 1,
+			"priority": 7.5,
+			"movespeed": 0.008
+		},
+		{
+			"code": "villagergotowork",
+			"priority": 5.5,
+			"movespeed": 0.008,
+			"animation": "Walk",
+			"minduration": 4000,
+			"maxduration": 6000,
+			"mincooldown": 20000,
+			"maxcooldown": 45000,
+			"duringDayTimeFrames": [ { "fromHour": 7, "toHour": 16.9 } ],
+			"maxdistance": 75
+		},
+		{
+			"code": "villagerfilltrough",
+			"minduration": 4000,
+			"maxduration": 6000,
+			"mincooldown": 40000,
+			"maxcooldown": 80000,
+			"maxdistance": 20,
+			"animation": "walk",
+			"animationSpeed": 1,
+			"priority": 5.0,
+			"movespeed": 0.008,
+			"duringDayTimeFrames": [ { "fromHour": 8, "toHour": 16 } ]
+		},
+{
+    "code": "villagercultivatecrops",
+    "minduration": 4000,
+    "maxduration": 6000,
+    "mincooldown": 15000,         
+    "maxcooldown": 30000,        
+    "maxdistance": 20,
+    "animation": "walk",
+    "animationSpeed": 1,
+    "priority": 5.0,
+    "movespeed": 0.008,
+    "farmlandCooldownSeconds": 20, 
+    "duringDayTimeFrames": [ { "fromHour": 7.5, "toHour": 16 } ]
+},
+
+
+
+{
+    "code": "villagerwander",
+    "priority": 4.8,
+    "moveSpeed": 0.005,
+    "animation": "walk",
+    "wanderRange": 15,
+    "wanderCooldownSeconds": 30,
+    "entitySuffix": "-shepherd",
+    "duringDayTimeFrames": [ { "fromHour": 8, "toHour": 16 } ]
+},
+
+		{
+			"code": "villagergotogather",
+ 
+			"priority": 5.5,
+			"movespeed": 0.008,
+			"animation": "walk",
+			"minduration": 4000,
+			"maxduration": 6000,
+			"mincooldown": 25000,
+			"maxcooldown": 50000,
+			"duringDayTimeFrames": [ { "fromHour": 17, "toHour": 20.9 } ],
+			"maxdistance": 75
+		},
+		{
+			"code": "villagersocialize",
+			"slot": 1,
+			"priority": 2.5,
+			"mincooldown": 15000,
+			"maxcooldown": 45000,
+			"minduration": 3000,
+			"maxduration": 8000,
+			"movespeed": 0.008,
+			"animation": "Walk",
+			"interact": "welcome",
+			"duringDayTimeFrames": [ 
+				{ "fromHour": 7, "toHour": 20.5 }
+			]
+		},
+		{
+			"code": "idle",
+			"priority": 1.0,
+			"minduration": 2000,
+			"maxduration": 4000,
+			"mincooldown": 20000,
+			"maxcooldown": 60000,
+			"animation": "idleyawn"
+		},
+		{
+			"code": "idle",
+			"priority": 1.0,
+			"minduration": 2000,
+			"maxduration": 4000,
+			"mincooldown": 25000,
+			"maxcooldown": 70000,
+			"animation": "idlescratchhead"
+		},
+		{
+			"code": "idle",
+			"priority": 0.7,
+			"minduration": 3000,
+			"maxduration": 6000,
+			"mincooldown": 15000,
+			"maxcooldown": 40000,
+			"animation": "idlelook"
+		},
+
+		{
+			"code": "idle",
+			"priority": 0.5,
+			"minduration": 5000,
+			"maxduration": 12000,
+			"mincooldown": 10000,
+			"maxcooldown": 40000,
+			"animation": "idle"
+		},
+		{
+			"code": "lookaround",
+			"priority": 0.3,
+			"minduration": 3000,
+			"maxduration": 6000,
+			"mincooldown": 15000,
+			"maxcooldown": 45000
+		}
+	]
+},
+
+
 			{
 				"code": "Villager",
 				"professionByType": {

--- a/VSVillage/src/Entity/AITask/AiTaskGotoAndInteract.cs
+++ b/VSVillage/src/Entity/AITask/AiTaskGotoAndInteract.cs
@@ -1,95 +1,507 @@
-using System.Security.Principal;
+﻿using System;
+using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
-using Vintagestory.GameContent;
 
 namespace VsVillage
 {
-    public abstract class AiTaskGotoAndInteract : AiTaskBase
-    {
-        protected float maxDistance { get; set; }
+	// Token: 0x0200000F RID: 15
+	public abstract class AiTaskGotoAndInteract : AiTaskBase
+	{
+		// Token: 0x1700000A RID: 10
+		// (get) Token: 0x06000063 RID: 99 RVA: 0x00002649 File Offset: 0x00000849
+		// (set) Token: 0x06000064 RID: 100 RVA: 0x00002651 File Offset: 0x00000851
+		protected float maxDistance { get; set; }
 
-        protected float moveSpeed;
-        protected long lastSearch;
-        protected long lastExecution;
-        protected bool stuck;
+		// Token: 0x06000065 RID: 101 RVA: 0x00004B2C File Offset: 0x00002D2C
+		public AiTaskGotoAndInteract(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig)
+			: base(entity, taskConfig, aiConfig)
+		{
+			this.maxDistance = taskConfig["maxdistance"].AsFloat(5f);
+			this.moveSpeed = taskConfig["movespeed"].AsFloat(0.08f);
+			this.interactAnim = new AnimationMetaData
+			{
+				Code = "interact",
+				Animation = taskConfig["interact"].AsString("interact")
+			}.Init();
+			this.pathfinder = new VillagerAStarNew(entity.World.GetCachingBlockAccessor(false, false));
+			this.lastPosition = null;
+			this.stuckCheckTime = 0L;
+			this.timesStuck = 0;
+			this.lastRepathTime = 0L;
+			this.currentlyOpeningDoor = null;
+			this.doorOpenedTime = 0L;
+		}
 
-        protected Vec3d targetPos;
+		// Token: 0x06000066 RID: 102 RVA: 0x00004BF8 File Offset: 0x00002DF8
+		public override bool ShouldExecute()
+		{
+			long elapsedMilliseconds = this.entity.World.ElapsedMilliseconds;
+			bool flag = 5000L + this.lastSearch < elapsedMilliseconds && this.cooldownUntilMs + this.lastExecution < elapsedMilliseconds;
+			bool flag2 = flag;
+			bool flag3 = flag2;
+			if (flag3)
+			{
+				this.lastSearch = elapsedMilliseconds;
+				this.targetPos = this.GetTargetPos();
+			}
+			return this.targetPos != null && this.cooldownUntilMs + this.lastExecution < elapsedMilliseconds;
+		}
 
-        protected AnimationMetaData interactAnim;
+		// Token: 0x06000067 RID: 103
+		protected abstract Vec3d GetTargetPos();
 
-        protected bool targetReached;
+		// Token: 0x06000068 RID: 104 RVA: 0x00004C80 File Offset: 0x00002E80
+		public override void StartExecute()
+		{
+			this.pathfinder.blockAccessor.Begin();
+			this.pathfinder.SetEntityCollisionBox(this.entity);
+			BlockPos startPos = this.pathfinder.GetStartPos(this.entity.ServerPos.XYZ);
+			BlockPos asBlockPos = this.targetPos.AsBlockPos;
+			this.currentPath = this.pathfinder.FindPath(startPos, asBlockPos, 1000);
+			this.pathfinder.blockAccessor.Commit();
+			bool flag = this.currentPath != null && this.currentPath.Count > 0;
+			bool flag2 = flag;
+			if (flag2)
+			{
+				this.entity.World.Logger.Debug("Found path with " + this.currentPath.Count.ToString() + " nodes");
+				this.currentPathIndex = 0;
+				this.stuck = false;
+				this.targetReached = false;
+				this.lastPosition = this.entity.ServerPos.XYZ.Clone();
+				this.stuckCheckTime = this.entity.World.ElapsedMilliseconds;
+				this.timesStuck = 0;
+			}
+			else
+			{
+				this.entity.World.Logger.Debug("No path found to target");
+				this.stuck = true;
+			}
+			base.StartExecute();
+		}
 
-        public AiTaskGotoAndInteract(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig) : base(entity, taskConfig, aiConfig)
-      {
-          maxDistance = taskConfig["maxdistance"].AsFloat(5);
-          moveSpeed = taskConfig["movespeed"].AsFloat(0.03f);
+		// Token: 0x06000069 RID: 105 RVA: 0x00004DDC File Offset: 0x00002FDC
+		public override bool ContinueExecute(float dt)
+		{
+			this.CheckIfStuck();
+			bool flag = this.targetReached;
+			bool flag2 = flag;
+			bool flag3;
+			if (flag2)
+			{
+				flag3 = this.entity.AnimManager.IsAnimationActive(new string[] { this.interactAnim.Code });
+			}
+			else
+			{
+				bool flag4 = !this.targetReached && this.targetPos != null && this.currentPath != null;
+				bool flag5 = flag4;
+				if (flag5)
+				{
+					this.HandlePathTraversal();
+				}
+				bool flag6 = this.InteractionPossible();
+				bool flag7 = flag6;
+				if (flag7)
+				{
+					this.entity.Controls.WalkVector.Set(0.0, 0.0, 0.0);
+					this.entity.Controls.StopAllMovement();
+					this.entity.AnimManager.StopAnimation(this.animMeta.Code);
+					this.entity.AnimManager.StartAnimation(this.interactAnim);
+					this.targetReached = true;
+					flag3 = true;
+				}
+				else
+				{
+					flag3 = !this.stuck && this.currentPath != null;
+				}
+			}
+			return flag3;
+		}
 
-          interactAnim = new AnimationMetaData
-          {
-            Code = "interact",
-            Animation = taskConfig["interact"].AsString("interact")
-          }.Init();
-        }
+		// Token: 0x0600006A RID: 106 RVA: 0x00004F14 File Offset: 0x00003114
+		protected virtual bool InteractionPossible()
+		{
+			return this.targetPos != null && this.entity.ServerPos.SquareDistanceTo(this.targetPos) < 2.25;
+		}
 
-        public override bool ShouldExecute()
-        {
-            var elapsedMs = entity.World.ElapsedMilliseconds;
-            if (5000 + lastSearch < elapsedMs && cooldownUntilMs + lastExecution < elapsedMs)
-            {
-                lastSearch = elapsedMs;
-                targetPos = GetTargetPos();
-            }
-            return targetPos != null && cooldownUntilMs + lastExecution < elapsedMs;
-        }
+		// Token: 0x0600006B RID: 107 RVA: 0x00004F58 File Offset: 0x00003158
+		public override void FinishExecute(bool cancelled)
+		{
+			base.FinishExecute(cancelled);
+			this.entity.Controls.WalkVector.Set(0.0, 0.0, 0.0);
+			this.entity.Controls.StopAllMovement();
+			this.entity.AnimManager.StopAnimation(this.animMeta.Code);
+			this.CloseAllOpenDoors();
+			bool flag = this.targetReached;
+			bool flag2 = flag;
+			if (flag2)
+			{
+				this.ApplyInteractionEffect();
+				this.lastExecution = this.entity.World.ElapsedMilliseconds;
+			}
+			this.entity.AnimManager.StopAnimation("interact");
+			this.targetPos = null;
+			this.targetReached = false;
+			this.currentPath = null;
+			this.lastPosition = null;
+			this.timesStuck = 0;
+			this.currentlyOpeningDoor = null;
+		}
 
-        protected abstract Vec3d GetTargetPos();
+		// Token: 0x0600006C RID: 108
+		protected abstract void ApplyInteractionEffect();
 
-        public override void StartExecute()
-        {
-            stuck = !pathTraverser.NavigateTo(targetPos, moveSpeed, 0.5f, () => stuck = true, () => stuck = true, null, true, 999, 0, null);
-            targetReached = false;
-            base.StartExecute();
-        }
+		// Token: 0x0600006D RID: 109 RVA: 0x00005040 File Offset: 0x00003240
+		protected void ToggleDoor(bool opened, BlockPos target)
+		{
+			Block block = this.entity.World.BlockAccessor.GetBlock(target);
+			bool flag = block != null && block.Code != null;
+			bool flag2 = flag;
+			if (flag2)
+			{
+				bool flag3 = block.Code.Path.Contains("door") || block.Code.Path.Contains("gate");
+				bool flag4 = flag3;
+				if (flag4)
+				{
+					BlockSelection blockSelection = new BlockSelection
+					{
+						Block = block,
+						Position = target,
+						HitPosition = new Vec3d(0.5, 0.5, 0.5),
+						Face = BlockFacing.NORTH
+					};
+					TreeAttribute treeAttribute = new TreeAttribute();
+					treeAttribute.SetBool("opened", opened);
+					try
+					{
+						block.Activate(this.entity.World, new Caller
+						{
+							Entity = this.entity,
+							Type = EnumCallerType.Entity,
+							Pos = this.entity.Pos.XYZ
+						}, blockSelection, treeAttribute);
+						this.entity.World.Logger.Debug("Toggled door at " + target.ToString() + " to " + (opened ? "open" : "closed"));
+					}
+					catch (Exception ex)
+					{
+						this.entity.World.Logger.Error("Failed to toggle door at " + target.ToString() + ": " + ex.Message);
+					}
+				}
+			}
+		}
 
-        public override bool ContinueExecute(float dt)
-        {
-            if (targetReached)
-            {
-                return entity.AnimManager.IsAnimationActive(interactAnim.Code);
-            }
-            else if (InteractionPossible())
-            {
-                entity.AnimManager.StopAnimation(animMeta.Code);
-                entity.AnimManager.StartAnimation(interactAnim);
-                pathTraverser.Stop();
-                targetReached = true;
-                return true;
-            }
-            return !stuck && pathTraverser.Active;
-        }
+		// Token: 0x0600006E RID: 110 RVA: 0x000051E4 File Offset: 0x000033E4
+		private void HandlePathTraversal()
+		{
+			bool flag = this.currentlyOpeningDoor != null;
+			bool flag2 = flag;
+			if (flag2)
+			{
+				long num = this.entity.World.ElapsedMilliseconds - this.doorOpenedTime;
+				bool flag3 = num < 500L;
+				bool flag4 = flag3;
+				if (flag4)
+				{
+					this.entity.Controls.WalkVector.Set(0.0, 0.0, 0.0);
+					return;
+				}
+				this.currentlyOpeningDoor = null;
+			}
+			bool flag5 = this.currentPath == null || this.currentPathIndex >= this.currentPath.Count;
+			bool flag6 = flag5;
+			if (flag6)
+			{
+				this.stuck = true;
+			}
+			else
+			{
+				VillagerPathNode villagerPathNode = this.currentPath[this.currentPathIndex];
+				Vec3d vec3d = villagerPathNode.BlockPos.ToVec3d().Add(0.5, 0.0, 0.5);
+				Vec3d xyz = this.entity.ServerPos.XYZ;
+				double num2 = xyz.X - vec3d.X;
+				double num3 = xyz.Z - vec3d.Z;
+				double num4 = Math.Sqrt(num2 * num2 + num3 * num3);
+				bool flag7 = num4 < 0.5;
+				bool flag8 = flag7;
+				if (flag8)
+				{
+					this.currentPathIndex++;
+					bool flag9 = this.currentPathIndex < this.currentPath.Count;
+					bool flag10 = flag9;
+					if (flag10)
+					{
+						VillagerPathNode villagerPathNode2 = this.currentPath[this.currentPathIndex];
+						bool isDoor = villagerPathNode2.IsDoor;
+						bool flag11 = isDoor;
+						if (flag11)
+						{
+							this.entity.World.Logger.Debug("Opening door at " + villagerPathNode2.BlockPos.ToString());
+							this.ToggleDoor(true, villagerPathNode2.BlockPos);
+							this.currentlyOpeningDoor = villagerPathNode2.BlockPos.Copy();
+							this.doorOpenedTime = this.entity.World.ElapsedMilliseconds;
+						}
+					}
+					bool isDoor2 = villagerPathNode.IsDoor;
+					bool flag12 = isDoor2;
+					if (flag12)
+					{
+						this.entity.World.Logger.Debug("Closing door behind at " + villagerPathNode.BlockPos.ToString());
+						BlockPos doorPos = villagerPathNode.BlockPos.Copy();
+						this.entity.World.RegisterCallback(delegate(float dtt)
+						{
+							this.ToggleDoor(false, doorPos);
+						}, 2000);
+					}
+				}
+				bool flag13 = this.currentPathIndex < this.currentPath.Count;
+				bool flag14 = flag13;
+				if (flag14)
+				{
+					VillagerPathNode villagerPathNode3 = this.currentPath[this.currentPathIndex];
+					Vec3d vec3d2 = villagerPathNode3.BlockPos.ToVec3d().Add(0.5, 0.0, 0.5);
+					Vec3d vec3d3 = vec3d2.Clone().Sub(xyz);
+					vec3d3.Y = 0.0;
+					vec3d3 = vec3d3.Normalize();
+					float num5 = (float)Math.Atan2(vec3d3.X, vec3d3.Z);
+					this.entity.ServerPos.Yaw = num5;
+					double num6 = (double)this.moveSpeed;
+					this.entity.Controls.WalkVector.Set(vec3d3.X * num6, 0.0, vec3d3.Z * num6);
+					bool flag15 = !this.entity.AnimManager.IsAnimationActive(new string[] { this.animMeta.Code });
+					bool flag16 = flag15;
+					if (flag16)
+					{
+						this.entity.AnimManager.StartAnimation(this.animMeta);
+					}
+				}
+			}
+		}
 
-        protected virtual bool InteractionPossible() => entity.ServerPos.SquareDistanceTo(targetPos) < 1.5f * 1.5f;
+		// Token: 0x0600006F RID: 111 RVA: 0x000055C8 File Offset: 0x000037C8
+		protected void CloseAllOpenDoors()
+		{
+			bool flag = this.currentPath != null;
+			bool flag2 = flag;
+			if (flag2)
+			{
+				for (int i = 0; i < this.currentPath.Count; i++)
+				{
+					VillagerPathNode villagerPathNode = this.currentPath[i];
+					bool isDoor = villagerPathNode.IsDoor;
+					bool flag3 = isDoor;
+					if (flag3)
+					{
+						Block block = this.entity.World.BlockAccessor.GetBlock(villagerPathNode.BlockPos);
+						bool flag4 = block != null && block.Code != null && (block.Code.Path.Contains("opened") || block.Code.Path.Contains("open"));
+						bool flag5 = flag4;
+						if (flag5)
+						{
+							this.ToggleDoor(false, villagerPathNode.BlockPos);
+						}
+					}
+				}
+			}
+		}
 
-        public override void FinishExecute(bool cancelled)
-        {
-            base.FinishExecute(cancelled);
-            pathTraverser.Stop();
-            if (targetReached)
-            {
-                ApplyInteractionEffect();
-                lastExecution = entity.World.ElapsedMilliseconds;
-            }
-            entity.AnimManager.StopAnimation("interact");
-            targetPos = null;
-            targetReached = false;
-        }
+		// Token: 0x06000070 RID: 112 RVA: 0x000056B0 File Offset: 0x000038B0
+		private void CheckIfStuck()
+		{
+			long elapsedMilliseconds = this.entity.World.ElapsedMilliseconds;
+			bool flag = elapsedMilliseconds - this.stuckCheckTime < 3000L;
+			bool flag2 = !flag;
+			if (flag2)
+			{
+				Vec3d xyz = this.entity.ServerPos.XYZ;
+				bool flag3 = this.lastPosition != null;
+				bool flag4 = flag3;
+				if (flag4)
+				{
+					double num = (double)xyz.DistanceTo(this.lastPosition);
+					bool flag5 = num < 0.5;
+					bool flag6 = flag5;
+					if (flag6)
+					{
+						this.timesStuck++;
+						this.entity.World.Logger.Warning(string.Concat(new string[]
+						{
+							"Villager appears stuck! Distance moved: ",
+							num.ToString("F2"),
+							" (stuck count: ",
+							this.timesStuck.ToString(),
+							")"
+						}));
+						bool flag7 = this.timesStuck <= 5;
+						bool flag8 = flag7;
+						if (flag8)
+						{
+							long num2 = elapsedMilliseconds - this.lastRepathTime;
+							bool flag9 = num2 > 5000L;
+							bool flag10 = flag9;
+							if (flag10)
+							{
+								this.entity.World.Logger.Notification("Recovery attempt " + this.timesStuck.ToString() + ": Re-pathing");
+								this.AttemptRepath();
+								this.lastRepathTime = elapsedMilliseconds;
+							}
+						}
+						else
+						{
+							bool flag11 = this.timesStuck >= 6;
+							bool flag12 = flag11;
+							if (flag12)
+							{
+								this.entity.World.Logger.Notification("Recovery attempt FINAL: Teleporting (last resort)");
+								this.TeleportToRecoveryPosition();
+								this.timesStuck = 0;
+							}
+						}
+					}
+					else
+					{
+						bool flag13 = this.timesStuck > 0;
+						bool flag14 = flag13;
+						if (flag14)
+						{
+							this.entity.World.Logger.Debug("Villager is moving again! Distance: " + num.ToString("F2"));
+						}
+						this.timesStuck = 0;
+					}
+				}
+				this.lastPosition = xyz.Clone();
+				this.stuckCheckTime = elapsedMilliseconds;
+			}
+		}
 
-        protected abstract void ApplyInteractionEffect();
-    }
-    public enum ExecutionState
-    {
-        ON_THE_WAY, INTERACTING, ABORTED
-    }
+		// Token: 0x06000071 RID: 113 RVA: 0x000058C4 File Offset: 0x00003AC4
+		private void AttemptRepath()
+		{
+			bool flag = this.targetPos == null;
+			bool flag2 = !flag;
+			if (flag2)
+			{
+				this.entity.World.Logger.Debug("Attempting to find new path to target");
+				this.pathfinder.blockAccessor.Begin();
+				this.pathfinder.SetEntityCollisionBox(this.entity);
+				BlockPos startPos = this.pathfinder.GetStartPos(this.entity.ServerPos.XYZ);
+				BlockPos asBlockPos = this.targetPos.AsBlockPos;
+				List<VillagerPathNode> list = this.pathfinder.FindPath(startPos, asBlockPos, 1000);
+				this.pathfinder.blockAccessor.Commit();
+				bool flag3 = list != null && list.Count > 0;
+				bool flag4 = flag3;
+				if (flag4)
+				{
+					this.entity.World.Logger.Notification("Found new path with " + list.Count.ToString() + " nodes");
+					this.currentPath = list;
+					this.currentPathIndex = 0;
+					this.stuck = false;
+				}
+				else
+				{
+					this.entity.World.Logger.Warning("Could not find alternative path");
+				}
+			}
+		}
+
+		// Token: 0x06000072 RID: 114 RVA: 0x00005A00 File Offset: 0x00003C00
+		private void TeleportToRecoveryPosition()
+		{
+			Vec3d vec3d = null;
+			bool flag = this.currentPath != null && this.currentPathIndex < this.currentPath.Count;
+			bool flag2 = flag;
+			if (flag2)
+			{
+				int num = Math.Min(2, this.currentPath.Count - this.currentPathIndex - 1);
+				bool flag3 = num > 0;
+				bool flag4 = flag3;
+				if (flag4)
+				{
+					VillagerPathNode villagerPathNode = this.currentPath[this.currentPathIndex + num];
+					vec3d = villagerPathNode.BlockPos.ToVec3d().Add(0.5, 0.1, 0.5);
+					this.currentPathIndex += num;
+					this.entity.World.Logger.Notification("Teleporting " + num.ToString() + " nodes ahead to " + vec3d.ToString());
+				}
+			}
+			bool flag5 = vec3d == null && this.targetPos != null;
+			bool flag6 = flag5;
+			if (flag6)
+			{
+				Vec3d xyz = this.entity.ServerPos.XYZ;
+				Vec3d vec3d2 = this.targetPos.Clone().Sub(xyz).Normalize();
+				vec3d = xyz.Add(vec3d2.X * 2.0, 0.5, vec3d2.Z * 2.0);
+				this.entity.World.Logger.Notification("Teleporting toward target to " + vec3d.ToString());
+			}
+			bool flag7 = vec3d != null;
+			bool flag8 = flag7;
+			if (flag8)
+			{
+				IBlockAccessor blockAccessor = this.entity.World.BlockAccessor;
+				BlockPos asBlockPos = vec3d.AsBlockPos;
+				Block block = blockAccessor.GetBlock(asBlockPos);
+				Block block2 = blockAccessor.GetBlock(asBlockPos.UpCopy(1));
+				bool flag9 = block.CollisionBoxes == null || block.CollisionBoxes.Length == 0;
+				bool flag10 = block2.CollisionBoxes == null || block2.CollisionBoxes.Length == 0;
+				bool flag11 = flag9 && flag10;
+				bool flag12 = flag11;
+				if (flag12)
+				{
+					this.entity.TeleportTo(vec3d);
+					this.entity.World.Logger.Notification("Teleported villager to " + vec3d.ToString());
+					this.entity.ServerPos.Motion.Y = 0.1;
+				}
+				else
+				{
+					this.entity.World.Logger.Warning("Teleport destination " + vec3d.ToString() + " is not safe, skipping");
+					this.stuck = true;
+				}
+			}
+		}
+
+		// Token: 0x04000025 RID: 37
+		protected float moveSpeed;
+
+		// Token: 0x04000026 RID: 38
+		protected long lastSearch;
+
+		// Token: 0x04000027 RID: 39
+		protected long lastExecution;
+
+		// Token: 0x04000028 RID: 40
+		protected bool stuck;
+
+		// Token: 0x04000029 RID: 41
+		protected Vec3d targetPos;
+
+		// Token: 0x0400002A RID: 42
+		protected AnimationMetaData interactAnim;
+
+		// Token: 0x0400002B RID: 43
+		protected bool targetReached;
+
+		// Token: 0x0400002C RID: 44
+		protected List<VillagerPathNode> currentPath;
+
+		// Token: 0x0400002D RID: 45
+		protected int currentPathIndex;
+
+		// Token: 0x0400002E RID: 46
+		protected VillagerAStarNew pathfinder;
+
+		// Token: 0x0400002F RID: 47
+		protected Vec3d lastPosition;
+
+		// Token: 0x04000030 RID: 48
+		protected long stuckCheckTime;
+
+		// Token: 0x04000031 RID: 49
+		protected int timesStuck;
+
+		// Token: 0x04000032 RID: 50
+		protected long lastRepathTime;
+
+		// Token: 0x04000033 RID: 51
+		protected BlockPos currentlyOpeningDoor;
+
+		// Token: 0x04000034 RID: 52
+		protected long doorOpenedTime;
+	}
 }

--- a/VSVillage/src/Entity/AITask/AiTaskHealWounded.cs
+++ b/VSVillage/src/Entity/AITask/AiTaskHealWounded.cs
@@ -1,5 +1,5 @@
+﻿using System;
 using System.Linq;
-using HarmonyLib;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
 using Vintagestory.API.Datastructures;
@@ -8,83 +8,185 @@ using Vintagestory.GameContent;
 
 namespace VsVillage
 {
-    public class AiTaskHealWounded : AiTaskGotoAndInteract
-    {
+	// Token: 0x02000012 RID: 18
+	public class AiTaskHealWounded : AiTaskGotoAndInteract
+	{
+		// Token: 0x06000075 RID: 117 RVA: 0x00002679 File Offset: 0x00000879
+		public AiTaskHealWounded(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig)
+			: base(entity, taskConfig, aiConfig)
+		{
+		}
 
-        public Entity woundedEntity;
-        public AiTaskHealWounded(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig) : base(entity, taskConfig, aiConfig)
-    {
-        }
+		// Token: 0x06000076 RID: 118 RVA: 0x00005CAC File Offset: 0x00003EAC
+		protected override Vec3d GetTargetPos()
+		{
+			bool flag = !this.IsHerbalist();
+			bool flag2 = flag;
+			bool flag3 = flag2;
+			Vec3d vec3d;
+			if (flag3)
+			{
+				vec3d = null;
+			}
+			else
+			{
+				Entity[] array = this.entity.World.GetEntitiesAround(this.entity.ServerPos.XYZ, base.maxDistance, 5f, (Entity entity) => entity is EntityVillager || entity is EntityTrader || entity is EntityPlayer);
+				EntityBehaviorVillager behavior = this.entity.GetBehavior<EntityBehaviorVillager>();
+				bool flag4 = ((behavior != null) ? behavior.Village : null) != null;
+				bool flag5 = flag4;
+				bool flag6 = flag5;
+				if (flag6)
+				{
+					Entity[] array2 = (from villager in behavior.Village.Villagers
+						where villager != null && villager.entity != null && villager.entity.Alive
+						select villager.entity).ToArray<Entity>();
+					array = array.Concat(array2).ToArray<Entity>();
+				}
+				int num = 0;
+				float num2 = 0f;
+				for (int i = 0; i < array.Length; i++)
+				{
+					EntityBehaviorHealth behavior2 = array[i].GetBehavior<EntityBehaviorHealth>();
+					bool flag7 = behavior2 != null && num2 < behavior2.MaxHealth - behavior2.Health;
+					bool flag8 = flag7;
+					bool flag9 = flag8;
+					if (flag9)
+					{
+						num2 = behavior2.MaxHealth - behavior2.Health;
+						num = i;
+					}
+					bool flag10 = behavior2 != null && behavior2.Health <= 0f;
+					bool flag11 = flag10;
+					bool flag12 = flag11;
+					if (flag12)
+					{
+						num2 = float.MaxValue;
+						num = i;
+					}
+				}
+				bool flag13 = num2 > 0.5f;
+				bool flag14 = flag13;
+				bool flag15 = flag14;
+				if (flag15)
+				{
+					this.woundedEntity = array[num];
+				}
+				Entity entity2 = this.woundedEntity;
+				bool flag16 = entity2 == null;
+				bool flag17 = flag16;
+				Vec3d vec3d2;
+				if (flag17)
+				{
+					vec3d2 = null;
+				}
+				else
+				{
+					EntityPos serverPos = entity2.ServerPos;
+					vec3d2 = ((serverPos != null) ? serverPos.XYZ : null);
+				}
+				vec3d = vec3d2;
+			}
+			return vec3d;
+		}
 
-        protected override Vec3d GetTargetPos()
-        {
-            var villagers = entity.World.GetEntitiesAround(entity.ServerPos.XYZ, maxDistance, 5, entity => entity is EntityVillager || entity is EntityTrader || entity is EntityPlayer);
-            if (entity.GetBehavior<EntityBehaviorVillager>()?.Village != null)
-            {
-                villagers = villagers.Concat(entity.GetBehavior<EntityBehaviorVillager>().Village.Villagers.ConvertAll(villager => villager.entity).ToArray()).ToArray();
-            }
-            int maxHpLossIndex = 0;
-            float maxHpLoss = 0;
-            for (int i = 0; i < villagers.Length; i++)
-            {
-                var health = villagers[i].GetBehavior<EntityBehaviorHealth>();
-                if (health != null && maxHpLoss < health.MaxHealth - health.Health)
-                {
-                    maxHpLoss = health.MaxHealth - health.Health;
-                    maxHpLossIndex = i;
-                }
-                // prefer dead targets
-                if (health != null && health.Health <= 0)
-                {
-                    maxHpLoss = int.MaxValue;
-                    maxHpLossIndex = i;
-                }
-            }
-            if (maxHpLoss > 0.5f)
-            {
-                woundedEntity = villagers[maxHpLossIndex];
-            }
-            return woundedEntity?.ServerPos?.XYZ;
-        }
+		// Token: 0x06000077 RID: 119 RVA: 0x00005ECC File Offset: 0x000040CC
+		protected override bool InteractionPossible()
+		{
+			return this.IsHerbalist() && this.woundedEntity != null && this.entity.ServerPos.SquareDistanceTo(this.woundedEntity.ServerPos) < 9f;
+		}
 
-        protected override bool InteractionPossible()
-        {
-            return entity.ServerPos.SquareDistanceTo(woundedEntity.ServerPos) < 2 * 2;
-        }
+		// Token: 0x06000078 RID: 120 RVA: 0x00005F14 File Offset: 0x00004114
+		protected override void ApplyInteractionEffect()
+		{
+			bool flag = !this.IsHerbalist();
+			bool flag2 = !flag;
+			bool flag3 = flag2;
+			if (flag3)
+			{
+				this.entity.AnimManager.StartAnimation(new AnimationMetaData
+				{
+					Animation = "holdbothhands",
+					Code = "holdbothhands",
+					AnimationSpeed = 1f,
+					BlendMode = EnumAnimationBlendMode.Average
+				}.Init());
+				this.entity.World.RegisterCallback(delegate(float dt)
+				{
+					this.PerformHealing();
+				}, 1000);
+			}
+		}
 
-        protected override void ApplyInteractionEffect()
-        {
-            if (woundedEntity.Alive)
-            {
-                woundedEntity.ReceiveDamage(new DamageSource()
-                {
-                    DamageTier = 0,
-                    HitPosition = woundedEntity.ServerPos.XYZ,
-                    Source = EnumDamageSource.Internal,
-                    SourceEntity = null, // otherwise the basegame wants to retaliate attacks ^^
-                    Type = EnumDamageType.Heal
-                }, 100);
-            }
-            else { woundedEntity.Revive(); }
+		// Token: 0x06000079 RID: 121 RVA: 0x00005FA0 File Offset: 0x000041A0
+		private bool IsHerbalist()
+		{
+			EntityAgent entity = this.entity;
+			bool flag = entity == null;
+			bool flag2 = flag;
+			bool? flag3;
+			if (flag2)
+			{
+				flag3 = null;
+			}
+			else
+			{
+				AssetLocation code = entity.Code;
+				bool flag4 = code == null;
+				bool flag5 = flag4;
+				if (flag5)
+				{
+					flag3 = null;
+				}
+				else
+				{
+					string path = code.Path;
+					flag3 = ((path != null) ? new bool?(path.EndsWith("-herbalist")) : null);
+				}
+			}
+			bool? flag6 = flag3;
+			return flag6.GetValueOrDefault();
+		}
 
-            SimpleParticleProperties smoke = new SimpleParticleProperties(
-                    10, 15,
-                    ColorUtil.ToRgba(75, 146, 175, 122),
-                    new Vec3d(),
-                    new Vec3d(2, 1, 2),
-                    new Vec3f(-0.25f, 0f, -0.25f),
-                    new Vec3f(0.25f, 0f, 0.25f),
-                    0.6f,
-                    -0.075f,
-                    0.5f,
-                    3f,
-                    EnumParticleModel.Quad
-                )
-            {
-                MinPos = woundedEntity.ServerPos.XYZ.AddCopy(-1.5, -0.5, -1.5)
-            };
-            entity.World.SpawnParticles(smoke);
-            woundedEntity = null;
-        }
-    }
+		// Token: 0x0600007A RID: 122 RVA: 0x00006034 File Offset: 0x00004234
+		private void PerformHealing()
+		{
+			bool flag = this.woundedEntity == null;
+			bool flag2 = !flag;
+			bool flag3 = flag2;
+			if (flag3)
+			{
+				bool alive = this.woundedEntity.Alive;
+				bool flag4 = alive;
+				bool flag5 = flag4;
+				if (flag5)
+				{
+					this.woundedEntity.ReceiveDamage(new DamageSource
+					{
+						DamageTier = 0,
+						HitPosition = this.woundedEntity.ServerPos.XYZ,
+						Source = EnumDamageSource.Internal,
+						SourceEntity = this.entity,
+						Type = EnumDamageType.Heal
+					}, 100f);
+				}
+				else
+				{
+					this.woundedEntity.Revive();
+				}
+				Vec3d xyz = this.woundedEntity.ServerPos.XYZ;
+				SimpleParticleProperties simpleParticleProperties = new SimpleParticleProperties(20f, 30f, ColorUtil.ToRgba(75, 146, 175, 222), xyz.AddCopy(-0.3, 0.5, -0.3), xyz.AddCopy(0.3, 2.0, 0.3), new Vec3f(-0.25f, 0f, -0.25f), new Vec3f(0.25f, 0.5f, 0.25f), 0.8f, -0.075f, 0.5f, 3f, EnumParticleModel.Quad);
+				simpleParticleProperties.MinPos = xyz.AddCopy(-0.5, 0.0, -0.5);
+				simpleParticleProperties.SelfPropelled = true;
+				this.entity.World.SpawnParticles(simpleParticleProperties, null);
+				SimpleParticleProperties simpleParticleProperties2 = new SimpleParticleProperties(15f, 20f, ColorUtil.ToRgba(255, 255, 255, 200), xyz.AddCopy(-0.2, 0.5, -0.2), xyz.AddCopy(0.2, 1.5, 0.2), new Vec3f(-0.1f, 0.1f, -0.1f), new Vec3f(0.1f, 0.3f, 0.1f), 0.5f, 0f, 0.2f, 0.8f, EnumParticleModel.Quad);
+				simpleParticleProperties2.MinPos = xyz.AddCopy(-0.3, 0.5, -0.3);
+				this.entity.World.SpawnParticles(simpleParticleProperties2, null);
+				this.entity.AnimManager.StopAnimation("holdbothhands");
+				this.woundedEntity = null;
+			}
+		}
+
+		// Token: 0x0400003B RID: 59
+		public Entity woundedEntity;
+	}
 }

--- a/VSVillage/src/Entity/AITask/AiTaskVillagerCultivateCrops.cs
+++ b/VSVillage/src/Entity/AITask/AiTaskVillagerCultivateCrops.cs
@@ -1,3 +1,5 @@
+﻿using System;
+using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
@@ -5,49 +7,169 @@ using Vintagestory.GameContent;
 
 namespace VsVillage
 {
-    public class AiTraskVillagerCultivateCrops : AiTaskGotoAndInteract
-    {
-        BlockEntityFarmland nearestFarmland;
+	// Token: 0x02000060 RID: 96
+	public class AiTaskVillagerCultivateCrops : AiTaskGotoAndInteract
+	{
+		// Token: 0x06000241 RID: 577 RVA: 0x00011F00 File Offset: 0x00010100
+		public AiTaskVillagerCultivateCrops(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig)
+			: base(entity, taskConfig, aiConfig)
+		{
+			this.recentlyCultivatedFarmland = new Dictionary<BlockPos, long>();
+			bool flag = taskConfig["farmlandCooldownSeconds"] != null;
+			bool flag2 = flag;
+			bool flag3 = flag2;
+			if (flag3)
+			{
+				this.farmlandCooldownMs = (long)(taskConfig["farmlandCooldownSeconds"].AsInt(60) * 1000);
+			}
+			else
+			{
+				this.farmlandCooldownMs = 60000L;
+			}
+		}
 
-        public AiTraskVillagerCultivateCrops(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig) : base(entity, taskConfig, aiConfig)
-    {
-        }
+		// Token: 0x06000242 RID: 578 RVA: 0x00011F6C File Offset: 0x0001016C
+		protected override Vec3d GetTargetPos()
+		{
+			bool flag = !this.IsFarmer();
+			bool flag2 = flag;
+			bool flag3 = flag2;
+			Vec3d vec3d;
+			if (flag3)
+			{
+				vec3d = null;
+			}
+			else
+			{
+				this.nearestFarmland = this.entity.Api.ModLoader.GetModSystem<POIRegistry>(true).GetNearestPoi(this.entity.ServerPos.XYZ, base.maxDistance, new PoiMatcher(this.isValidFarmland)) as BlockEntityFarmland;
+				bool flag4 = this.nearestFarmland == null;
+				bool flag5 = flag4;
+				bool flag6 = flag5;
+				if (flag6)
+				{
+					vec3d = null;
+				}
+				else
+				{
+					BlockPos pos = this.nearestFarmland.Pos;
+					this.entity.World.Logger.Debug("Cultivate: Found farmland at " + pos.ToString() + ", targeting directly");
+					vec3d = pos.ToVec3d().Add(0.5, 1.0, 0.5);
+				}
+			}
+			return vec3d;
+		}
 
-        protected override Vec3d GetTargetPos()
-        {
-            nearestFarmland = entity.Api.ModLoader.GetModSystem<POIRegistry>().GetNearestPoi(entity.ServerPos.XYZ, maxDistance, isValidFarmland) as BlockEntityFarmland;
-            return nearestFarmland?.Position;
-        }
+		// Token: 0x06000243 RID: 579 RVA: 0x00012068 File Offset: 0x00010268
+		protected override void ApplyInteractionEffect()
+		{
+			bool flag = !this.IsFarmer();
+			bool flag2 = !flag;
+			bool flag3 = flag2;
+			if (flag3)
+			{
+				bool flag4 = this.nearestFarmland == null;
+				bool flag5 = !flag4;
+				bool flag6 = flag5;
+				if (flag6)
+				{
+					bool flag7 = this.nearestFarmland.HasUnripeCrop();
+					bool flag8 = flag7;
+					bool flag9 = flag8;
+					if (flag9)
+					{
+						this.entity.AnimManager.StartAnimation(new AnimationMetaData
+						{
+							Animation = "hoe-till",
+							Code = "hoe-till",
+							AnimationSpeed = 1f,
+							BlendMode = EnumAnimationBlendMode.Average
+						}.Init());
+						this.entity.World.RegisterCallback(delegate(float dt)
+						{
+							this.PerformCultivation();
+						}, 1500);
+					}
+				}
+			}
+		}
 
-        protected override void ApplyInteractionEffect()
-        {
-            if (nearestFarmland.HasUnripeCrop())
-            {
-                nearestFarmland.TryGrowCrop(entity.World.Calendar.TotalHours + nearestFarmland.GetHoursForNextStage() + 1);
+		// Token: 0x06000244 RID: 580 RVA: 0x0001212C File Offset: 0x0001032C
+		private bool isValidFarmland(IPointOfInterest poi)
+		{
+			BlockEntityFarmland blockEntityFarmland = poi as BlockEntityFarmland;
+			return blockEntityFarmland != null && blockEntityFarmland.HasUnripeCrop() && !this.IsFarmlandOnCooldown(blockEntityFarmland.Pos) && this.entity.World.Rand.NextDouble() < 0.2;
+		}
 
-                SimpleParticleProperties fertilizer = new SimpleParticleProperties(
-                        10, 15,
-                        ColorUtil.ToRgba(255, 255, 233, 83),
-                        nearestFarmland.Position.AddCopy(-0.4, 0.8, -0.4),
-                        nearestFarmland.Position.AddCopy(-0.6, 0.8, -0.6),
-                        new Vec3f(-0.25f, 0f, -0.25f),
-                        new Vec3f(0.25f, 0f, 0.25f),
-                        2f,
-                        1f,
-                        0.2f,
-                        1f,
-                        EnumParticleModel.Cube
-                    );
+		// Token: 0x06000245 RID: 581 RVA: 0x00003831 File Offset: 0x00001A31
+		public override void FinishExecute(bool cancelled)
+		{
+			this.entity.AnimManager.StopAnimation("hoe-till");
+			base.FinishExecute(cancelled);
+		}
 
-                fertilizer.MinPos = targetPos.AddCopy(0.5, 1, 0.5);
-                entity.World.SpawnParticles(fertilizer);
-            }
-        }
+		// Token: 0x06000246 RID: 582 RVA: 0x00012184 File Offset: 0x00010384
+		private bool IsFarmer()
+		{
+			return this.entity != null && this.entity.Code != null && this.entity.Code.Path != null && this.entity.Code.Path.EndsWith("-farmer");
+		}
 
-        private bool isValidFarmland(IPointOfInterest poi)
-        {
-            var farmland = poi as BlockEntityFarmland;
-            return farmland != null && farmland.HasUnripeCrop() && entity.World.Rand.NextDouble() < 0.2;
-        }
-    }
+		// Token: 0x06000247 RID: 583 RVA: 0x000121E0 File Offset: 0x000103E0
+		private bool IsFarmlandOnCooldown(BlockPos pos)
+		{
+			long elapsedMilliseconds = this.entity.World.ElapsedMilliseconds;
+			List<BlockPos> list = new List<BlockPos>();
+			foreach (KeyValuePair<BlockPos, long> keyValuePair in this.recentlyCultivatedFarmland)
+			{
+				bool flag = elapsedMilliseconds - keyValuePair.Value > this.farmlandCooldownMs;
+				bool flag2 = flag;
+				bool flag3 = flag2;
+				if (flag3)
+				{
+					list.Add(keyValuePair.Key);
+				}
+			}
+			for (int i = 0; i < list.Count; i++)
+			{
+				this.recentlyCultivatedFarmland.Remove(list[i]);
+			}
+			long num;
+			return this.recentlyCultivatedFarmland.TryGetValue(pos, out num) && elapsedMilliseconds - num < this.farmlandCooldownMs;
+		}
+
+		// Token: 0x06000248 RID: 584 RVA: 0x00003852 File Offset: 0x00001A52
+		private void MarkFarmlandCultivated(BlockPos pos)
+		{
+			this.recentlyCultivatedFarmland[pos.Copy()] = this.entity.World.ElapsedMilliseconds;
+		}
+
+		// Token: 0x06000249 RID: 585 RVA: 0x000122D0 File Offset: 0x000104D0
+		private void PerformCultivation()
+		{
+			bool flag = this.nearestFarmland == null || !this.nearestFarmland.HasUnripeCrop();
+			bool flag2 = !flag;
+			bool flag3 = flag2;
+			if (flag3)
+			{
+				double totalHours = this.entity.World.Calendar.TotalHours;
+				double hoursForNextStage = this.nearestFarmland.GetHoursForNextStage();
+				double num = totalHours + hoursForNextStage + 1.0;
+				this.nearestFarmland.TryGrowCrop(num);
+				this.MarkFarmlandCultivated(this.nearestFarmland.Pos);
+				SimpleParticleProperties simpleParticleProperties = new SimpleParticleProperties(10f, 15f, ColorUtil.ToRgba(255, 255, 233, 83), this.nearestFarmland.Position.AddCopy(-0.4, 0.8, -0.4), this.nearestFarmland.Position.AddCopy(-0.6, 0.8, -0.6), new Vec3f(-0.25f, 0f, -0.25f), new Vec3f(0.25f, 0f, 0.25f), 2f, 1f, 0.2f, 1f, EnumParticleModel.Cube);
+				simpleParticleProperties.MinPos = this.nearestFarmland.Position.AddCopy(0.5, 1.0, 0.5);
+				this.entity.World.SpawnParticles(simpleParticleProperties, null);
+				this.entity.AnimManager.StopAnimation("hoe-till");
+				this.entity.World.Logger.Debug("Cultivate: Performed cultivation on farmland at " + this.nearestFarmland.Pos.ToString());
+			}
+		}
+
+		// Token: 0x0400016C RID: 364
+		private BlockEntityFarmland nearestFarmland;
+
+		// Token: 0x0400016D RID: 365
+		private Dictionary<BlockPos, long> recentlyCultivatedFarmland;
+
+		// Token: 0x0400016E RID: 366
+		private long farmlandCooldownMs;
+	}
 }

--- a/VSVillage/src/Entity/AITask/AiTaskVillagerFillTrough.cs
+++ b/VSVillage/src/Entity/AITask/AiTaskVillagerFillTrough.cs
@@ -1,3 +1,5 @@
+﻿using System;
+using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
@@ -5,48 +7,188 @@ using Vintagestory.GameContent;
 
 namespace VsVillage
 {
-    public class AiTraskVillagerFillTrough : AiTaskGotoAndInteract
-    {
-        BlockEntityTrough nearestTrough;
+	// Token: 0x02000061 RID: 97
+	public class AiTaskVillagerFillTrough : AiTaskGotoAndInteract
+	{
+		// Token: 0x0600024B RID: 587 RVA: 0x000124A0 File Offset: 0x000106A0
+		public AiTaskVillagerFillTrough(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig)
+			: base(entity, taskConfig, aiConfig)
+		{
+			this.recentlyFilledTroughs = new Dictionary<BlockPos, long>();
+			bool flag = taskConfig["troughCooldownSeconds"] != null;
+			bool flag2 = flag;
+			if (flag2)
+			{
+				this.troughCooldownMs = (long)(taskConfig["troughCooldownSeconds"].AsInt(60) * 1000);
+			}
+		}
 
-        public AiTraskVillagerFillTrough(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig) : base(entity, taskConfig, aiConfig)
-        {
-        }
+		// Token: 0x0600024C RID: 588 RVA: 0x00012504 File Offset: 0x00010704
+		protected override Vec3d GetTargetPos()
+		{
+			bool flag = !this.IsShepherd();
+			bool flag2 = flag;
+			Vec3d vec3d;
+			if (flag2)
+			{
+				vec3d = null;
+			}
+			else
+			{
+				this.nearestTrough = this.entity.Api.ModLoader.GetModSystem<POIRegistry>(true).GetNearestPoi(this.entity.ServerPos.XYZ, base.maxDistance, new PoiMatcher(this.isValidTrough)) as BlockEntityTrough;
+				bool flag3 = this.nearestTrough == null;
+				bool flag4 = flag3;
+				if (flag4)
+				{
+					vec3d = null;
+				}
+				else
+				{
+					this.entity.World.Logger.Notification("Shepherd found trough at: " + this.nearestTrough.Position.ToString());
+					vec3d = this.nearestTrough.Position;
+				}
+			}
+			return vec3d;
+		}
 
-        protected override Vec3d GetTargetPos()
-        {
-            nearestTrough = entity.Api.ModLoader.GetModSystem<POIRegistry>().GetNearestPoi(entity.ServerPos.XYZ, maxDistance, poi => poi is BlockEntityTrough) as BlockEntityTrough;
-            return nearestTrough?.Position;
-        }
+		// Token: 0x0600024D RID: 589 RVA: 0x000125D0 File Offset: 0x000107D0
+		protected override void ApplyInteractionEffect()
+		{
+			bool flag = !this.IsShepherd();
+			bool flag2 = !flag;
+			if (flag2)
+			{
+				bool flag3 = this.nearestTrough == null;
+				bool flag4 = !flag3;
+				if (flag4)
+				{
+					this.entity.World.Logger.Notification("Shepherd found trough at: " + this.nearestTrough.Position.ToString());
+					Item item = (this.nearestTrough.Inventory[0].Empty ? this.entity.World.GetItem(new AssetLocation("grain-flax")) : this.nearestTrough.Inventory[0].Itemstack.Item);
+					this.entity.World.Logger.Notification("Item to fill: " + ((item != null) ? item.Code.ToString() : "NULL"));
+					bool flag5 = item == null;
+					bool flag6 = !flag5;
+					if (flag6)
+					{
+						ItemSlot itemSlot = new DummySlot(new ItemStack(item, 16));
+						ContentConfig contentConfig = ItemSlotTrough.getContentConfig(this.entity.Api.World, this.nearestTrough.contentConfigs, itemSlot);
+						this.entity.World.Logger.Notification("ContentConfig: " + ((contentConfig != null) ? "Valid" : "NULL"));
+						bool flag7 = contentConfig == null;
+						bool flag8 = !flag7;
+						if (flag8)
+						{
+							this.entity.AnimManager.StartAnimation(new AnimationMetaData
+							{
+								Animation = "hoe-till",
+								Code = "hoe-till",
+								AnimationSpeed = 1f,
+								BlendMode = EnumAnimationBlendMode.Average
+							}.Init());
+							this.entity.World.RegisterCallback(delegate(float dt)
+							{
+								this.PerformFilling(itemSlot, contentConfig);
+							}, 1500);
+						}
+					}
+				}
+			}
+		}
 
-        protected override void ApplyInteractionEffect()
-        {
-            Item troughContent = nearestTrough.Inventory[0].Empty ? entity.World.GetItem(new AssetLocation("grain-flax")) : nearestTrough.Inventory[0].Itemstack.Item;
-            if (troughContent == null) { return; }
-            ItemSlot slot = new DummySlot(new ItemStack(troughContent, 16));
-            var contentConfig = ItemSlotTrough.getContentConfig(entity.Api.World, nearestTrough.contentConfigs, slot);
-            if (contentConfig != null)
-            {
-                slot.TryPutInto(entity.World, nearestTrough.Inventory[0], contentConfig.QuantityPerFillLevel);
-                nearestTrough.Inventory[0].MarkDirty();
+		// Token: 0x0600024E RID: 590 RVA: 0x00003831 File Offset: 0x00001A31
+		public override void FinishExecute(bool cancelled)
+		{
+			this.entity.AnimManager.StopAnimation("hoe-till");
+			base.FinishExecute(cancelled);
+		}
 
-                SimpleParticleProperties grain = new SimpleParticleProperties(
-                        10, 15,
-                        ColorUtil.ToRgba(255, 255, 233, 83),
-                        nearestTrough.Position.AddCopy(-0.4, 0.8, -0.4),
-                        nearestTrough.Position.AddCopy(-0.6, 0.8, -0.6),
-                        new Vec3f(-0.25f, 0f, -0.25f),
-                        new Vec3f(0.25f, 0f, 0.25f),
-                        2f,
-                        1f,
-                        0.2f,
-                        1f,
-                        EnumParticleModel.Cube
-                    );
+		// Token: 0x0600024F RID: 591 RVA: 0x000127E4 File Offset: 0x000109E4
+		private bool IsShepherd()
+		{
+			return this.entity != null && this.entity.Code != null && this.entity.Code.Path != null && this.entity.Code.Path.EndsWith("-shepherd");
+		}
 
-                grain.MinPos = targetPos.AddCopy(0.5, 1, 0.5);
-                entity.World.SpawnParticles(grain);
-            }
-        }
-    }
+		// Token: 0x06000250 RID: 592 RVA: 0x00012840 File Offset: 0x00010A40
+		private bool IsTroughOnCooldown(BlockPos pos)
+		{
+			long elapsedMilliseconds = this.entity.World.ElapsedMilliseconds;
+			List<BlockPos> list = new List<BlockPos>();
+			foreach (KeyValuePair<BlockPos, long> keyValuePair in this.recentlyFilledTroughs)
+			{
+				bool flag = elapsedMilliseconds - keyValuePair.Value > this.troughCooldownMs;
+				bool flag2 = flag;
+				if (flag2)
+				{
+					list.Add(keyValuePair.Key);
+				}
+			}
+			for (int i = 0; i < list.Count; i++)
+			{
+				this.recentlyFilledTroughs.Remove(list[i]);
+			}
+			long num;
+			return this.recentlyFilledTroughs.TryGetValue(pos, out num) && elapsedMilliseconds - num < this.troughCooldownMs;
+		}
+
+		// Token: 0x06000251 RID: 593 RVA: 0x00003881 File Offset: 0x00001A81
+		private void MarkTroughFilled(BlockPos pos)
+		{
+			this.recentlyFilledTroughs[pos.Copy()] = this.entity.World.ElapsedMilliseconds;
+		}
+
+		// Token: 0x06000252 RID: 594 RVA: 0x0001292C File Offset: 0x00010B2C
+		private void PerformFilling(ItemSlot itemSlot, ContentConfig contentConfig)
+		{
+			bool flag = this.nearestTrough == null;
+			bool flag2 = !flag;
+			if (flag2)
+			{
+				int num = itemSlot.TryPutInto(this.entity.World, this.nearestTrough.Inventory[0], contentConfig.QuantityPerFillLevel);
+				this.entity.World.Logger.Notification("Amount moved to trough: " + num.ToString());
+				this.nearestTrough.Inventory[0].MarkDirty();
+				this.MarkTroughFilled(this.nearestTrough.Pos);
+				SimpleParticleProperties simpleParticleProperties = new SimpleParticleProperties(10f, 15f, ColorUtil.ToRgba(255, 255, 233, 83), this.nearestTrough.Position.AddCopy(-0.4, 0.8, -0.4), this.nearestTrough.Position.AddCopy(-0.6, 0.8, -0.6), new Vec3f(-0.25f, 0f, -0.25f), new Vec3f(0.25f, 0f, 0.25f), 2f, 1f, 0.2f, 1f, EnumParticleModel.Cube);
+				simpleParticleProperties.MinPos = this.nearestTrough.Position.AddCopy(0.5, 1.0, 0.5);
+				this.entity.World.SpawnParticles(simpleParticleProperties, null);
+				this.entity.AnimManager.StopAnimation("hoe-till");
+			}
+		}
+
+		// Token: 0x06000253 RID: 595 RVA: 0x00012AE0 File Offset: 0x00010CE0
+		private bool isValidTrough(IPointOfInterest poi)
+		{
+			BlockEntityTrough blockEntityTrough = poi as BlockEntityTrough;
+			bool flag = blockEntityTrough == null || this.IsTroughOnCooldown(blockEntityTrough.Pos);
+			bool flag2 = flag;
+			bool flag3;
+			if (flag2)
+			{
+				flag3 = false;
+			}
+			else
+			{
+				ItemSlot itemSlot = blockEntityTrough.Inventory[0];
+				bool flag4 = itemSlot == null || itemSlot.Empty;
+				bool flag5 = flag4;
+				if (flag5)
+				{
+					flag3 = this.entity.World.Rand.NextDouble() < 0.3;
+				}
+				else
+				{
+					int stackSize = itemSlot.StackSize;
+					int maxStackSize = itemSlot.Itemstack.Collectible.MaxStackSize;
+					flag3 = stackSize < maxStackSize && this.entity.World.Rand.NextDouble() < 0.3;
+				}
+			}
+			return flag3;
+		}
+
+		// Token: 0x0400016F RID: 367
+		private BlockEntityTrough nearestTrough;
+
+		// Token: 0x04000170 RID: 368
+		private Dictionary<BlockPos, long> recentlyFilledTroughs;
+
+		// Token: 0x04000171 RID: 369
+		private long troughCooldownMs = 60000L;
+	}
 }

--- a/VSVillage/src/Entity/AITask/AiTaskVillagerGotoGatherspot.cs
+++ b/VSVillage/src/Entity/AITask/AiTaskVillagerGotoGatherspot.cs
@@ -1,65 +1,139 @@
+﻿using System;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
-using Vintagestory.API.Server;
-using Vintagestory.GameContent;
 
 namespace VsVillage
 {
-    public class AiTaskVillagerGotoGatherspot : AiTaskGotoAndInteract
-    {
-        float offset;
-        BlockEntityVillagerBrazier brazier;
+	// Token: 0x02000015 RID: 21
+	public class AiTaskVillagerGotoGatherspot : AiTaskGotoAndInteract
+	{
+		// Token: 0x06000087 RID: 135 RVA: 0x0000638C File Offset: 0x0000458C
+		public AiTaskVillagerGotoGatherspot(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig)
+			: base(entity, taskConfig, aiConfig)
+		{
+			this.offset = (float)entity.World.Rand.Next(taskConfig["minoffset"].AsInt(-50), taskConfig["maxoffset"].AsInt(50)) / 100f;
+		}
 
-        public AiTaskVillagerGotoGatherspot(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig) : base(entity, taskConfig, aiConfig )
-        {
-            // create random offset from -50 to 50 / 100 to add some variation to when AI tasks can be run
-            offset = ((float)entity.World.Rand.Next(taskConfig["minoffset"].AsInt(-50), taskConfig["maxoffset"].AsInt(50))) / 100;
-        }
+		// Token: 0x06000088 RID: 136 RVA: 0x000063E8 File Offset: 0x000045E8
+		protected override void ApplyInteractionEffect()
+		{
+			bool flag = this.brazier != null;
+			bool flag2 = flag;
+			if (flag2)
+			{
+				this.brazier.Ignite();
+				this.entity.World.Logger.Notification("Villager ignited brazier");
+			}
+			this.brazier = null;
+		}
 
-        protected override void ApplyInteractionEffect()
-        {
-            brazier?.Ignite();
-            brazier = null;
-        }
+		// Token: 0x06000089 RID: 137 RVA: 0x00006438 File Offset: 0x00004638
+		protected override Vec3d GetTargetPos()
+		{
+			ICoreAPI api = this.entity.Api;
+			EntityBehaviorVillager behavior = this.entity.GetBehavior<EntityBehaviorVillager>();
+			Village village = ((behavior != null) ? behavior.Village : null);
+			BlockPos blockPos = ((village != null) ? village.FindRandomGatherplace() : null);
+			this.brazier = ((blockPos != null) ? api.World.BlockAccessor.GetBlockEntity<BlockEntityVillagerBrazier>(blockPos) : null);
+			Vec3d vec3d = ((this.brazier != null) ? this.brazier.Position : null);
+			bool flag = vec3d == null;
+			bool flag2 = flag;
+			Vec3d vec3d2;
+			if (flag2)
+			{
+				this.entity.World.Logger.Debug("No gatherplace found for villager");
+				vec3d2 = null;
+			}
+			else
+			{
+				this.entity.World.Logger.Notification("Villager going to gatherplace at " + vec3d.ToString());
+				vec3d2 = this.getRandomPosNearby(vec3d);
+			}
+			return vec3d2;
+		}
 
-        protected override Vec3d GetTargetPos()
-        {
-            var api = entity.Api;
-            var village = entity.GetBehavior<EntityBehaviorVillager>()?.Village;
-            var brazierPos = village?.FindRandomGatherplace();
-            brazier = brazierPos != null ? api.World.BlockAccessor.GetBlockEntity<BlockEntityVillagerBrazier>(brazierPos) : null;
-            return getRandomPosNearby(brazier?.Position);
-        }
+		// Token: 0x0600008A RID: 138 RVA: 0x0000651C File Offset: 0x0000471C
+		public override bool ShouldExecute()
+		{
+			bool flag = !IntervalUtil.matchesCurrentTime(this.duringDayTimeFrames, this.entity.World, this.offset);
+			bool flag2 = flag;
+			bool flag3;
+			if (flag2)
+			{
+				flag3 = false;
+			}
+			else
+			{
+				long elapsedMilliseconds = this.entity.World.ElapsedMilliseconds;
+				bool flag4 = elapsedMilliseconds - this.lastExecutionTime < 10000L;
+				bool flag5 = flag4;
+				flag3 = !flag5 && base.ShouldExecute();
+			}
+			return flag3;
+		}
 
-        public override bool ShouldExecute()
-        {
-            return base.ShouldExecute() && IntervalUtil.matchesCurrentTime(duringDayTimeFrames, entity.World, offset);
-        }
+		// Token: 0x0600008B RID: 139 RVA: 0x00006590 File Offset: 0x00004790
+		private Vec3d getRandomPosNearby(Vec3d middle)
+		{
+			bool flag = middle == null;
+			bool flag2 = flag;
+			Vec3d vec3d;
+			if (flag2)
+			{
+				vec3d = null;
+			}
+			else
+			{
+				IBlockAccessor blockAccessor = this.entity.World.BlockAccessor;
+				for (int i = 0; i < 5; i++)
+				{
+					int num = this.entity.World.Rand.Next(-3, 4);
+					int num2 = this.entity.World.Rand.Next(-3, 4);
+					Vec3d vec3d2 = middle.AddCopy((float)num2, 0f, (float)num);
+					bool flag3 = blockAccessor.GetBlock(vec3d2.AsBlockPos.Up(1)).Id == 0;
+					bool flag4 = flag3;
+					if (flag4)
+					{
+						this.entity.World.Logger.Debug("Found random position near gatherplace: " + vec3d2.ToString());
+						return vec3d2;
+					}
+				}
+				this.entity.World.Logger.Debug("Could not find open position, using center");
+				vec3d = middle;
+			}
+			return vec3d;
+		}
 
-        private Vec3d getRandomPosNearby(Vec3d middle)
-        {
-            if (middle == null)
-            {
-                return null;
-            }
-            int tries = 0;
-            var blockAccessor = entity.World.BlockAccessor;
+		// Token: 0x0600008C RID: 140 RVA: 0x0000669C File Offset: 0x0000489C
+		public override bool ContinueExecute(float dt)
+		{
+			return base.ContinueExecute(dt);
+		}
 
-            while (tries < 5)
-            {
-                tries++;
-                int offsetY = entity.World.Rand.Next(-3, 4);
-                int offsetX = entity.World.Rand.Next(-3, 4);
+		// Token: 0x0600008D RID: 141 RVA: 0x00002738 File Offset: 0x00000938
+		public override void FinishExecute(bool cancelled)
+		{
+			this.entity.World.Logger.Notification("GotoGatherspot: Finishing execution");
+			this.entity.Controls.StopAllMovement();
+			base.FinishExecute(cancelled);
+		}
 
-                var candidate = middle.AddCopy(offsetX, 0, offsetY);
+		// Token: 0x0600008E RID: 142 RVA: 0x0000276F File Offset: 0x0000096F
+		public override void StartExecute()
+		{
+			this.lastExecutionTime = this.entity.World.ElapsedMilliseconds;
+			this.entity.World.Logger.Notification("GotoGatherspot: Starting execution");
+			base.StartExecute();
+		}
 
-                if (blockAccessor.GetBlock(candidate.AsBlockPos.Up()).Id == 0)
-                {
-                    return candidate;
-                }
-            }
-            return middle;
-        }
-    }
+		// Token: 0x04000041 RID: 65
+		private float offset;
+
+		// Token: 0x04000042 RID: 66
+		private BlockEntityVillagerBrazier brazier;
+
+		// Token: 0x04000043 RID: 67
+		private long lastExecutionTime;
+	}
 }

--- a/VSVillage/src/Entity/AITask/AiTaskVillagerGotoWork.cs
+++ b/VSVillage/src/Entity/AITask/AiTaskVillagerGotoWork.cs
@@ -1,74 +1,199 @@
+﻿using System;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 
 namespace VsVillage
 {
-    public class AiTaskVillagerGotoWork : AiTaskGotoAndInteract
-    {
-        float offset;
+	// Token: 0x02000016 RID: 22
+	public class AiTaskVillagerGotoWork : AiTaskGotoAndInteract
+	{
+		// Token: 0x0600008F RID: 143 RVA: 0x000066B8 File Offset: 0x000048B8
+		public AiTaskVillagerGotoWork(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig)
+			: base(entity, taskConfig, aiConfig)
+		{
+			this.offset = (float)entity.World.Rand.Next(taskConfig["minoffset"].AsInt(-50), taskConfig["maxoffset"].AsInt(50)) / 100f;
+		}
 
-        public AiTaskVillagerGotoWork(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig) : base(entity, taskConfig, aiConfig)
-        {
-            offset = ((float)entity.World.Rand.Next(taskConfig["minoffset"].AsInt(-50), taskConfig["maxoffset"].AsInt(50))) / 100;
-        }
+		// Token: 0x06000090 RID: 144 RVA: 0x000027AA File Offset: 0x000009AA
+		protected override void ApplyInteractionEffect()
+		{
+		}
 
-        protected override void ApplyInteractionEffect()
-        {
-            // do nothing
-        }
+		// Token: 0x06000091 RID: 145 RVA: 0x00006714 File Offset: 0x00004914
+		protected override Vec3d GetTargetPos()
+		{
+			EntityBehaviorVillager behavior = this.entity.GetBehavior<EntityBehaviorVillager>();
+			Village village = ((behavior != null) ? behavior.Village : null);
+			bool flag = village == null;
+			Vec3d vec3d;
+			if (flag)
+			{
+				vec3d = null;
+			}
+			else
+			{
+				BlockPos blockPos = behavior.Workstation;
+				bool flag2 = blockPos == null;
+				if (flag2)
+				{
+					blockPos = village.FindFreeWorkstation(this.entity.EntityId, behavior.Profession);
+					behavior.Workstation = blockPos;
+				}
+				else
+				{
+					VillagerWorkstation villagerWorkstation;
+					village.Workstations.TryGetValue(blockPos, out villagerWorkstation);
+					bool flag3 = villagerWorkstation == null || villagerWorkstation.OwnerId != this.entity.EntityId;
+					if (flag3)
+					{
+						blockPos = null;
+						behavior.Workstation = null;
+					}
+				}
+				bool flag4 = blockPos != null;
+				if (flag4)
+				{
+					this.workstationPos = blockPos.Copy();
+				}
+				vec3d = this.getWorkstationStandingPos((blockPos != null) ? blockPos.ToVec3d() : null);
+			}
+			return vec3d;
+		}
 
-        protected override Vec3d GetTargetPos()
-        {
-            var villager = entity.GetBehavior<EntityBehaviorVillager>();
-            var village = villager?.Village;
-            if (village == null) return null;
-            var workPos = villager.Workstation;
-            if (workPos == null)
-            {
-                workPos = village.FindFreeWorkstation(entity.EntityId, villager.Profession);
-                villager.Workstation = workPos;
-            }
-            else
-            {
-                village.Workstations.TryGetValue(workPos, out var workstation);
-                if (workstation == null || workstation.OwnerId != entity.EntityId)
-                {
-                    workPos = null; 
-                    villager.Workstation = null;
-                }
-            }
-            return getRandomPosNearby(workPos?.ToVec3d());
-        }
+		// Token: 0x06000092 RID: 146 RVA: 0x00006800 File Offset: 0x00004A00
+		public override bool ShouldExecute()
+		{
+			return base.ShouldExecute() && IntervalUtil.matchesCurrentTime(this.duringDayTimeFrames, this.entity.World, this.offset);
+		}
 
+		// Token: 0x06000093 RID: 147 RVA: 0x0000683C File Offset: 0x00004A3C
+		private Vec3d getRandomPosNearby(Vec3d middle)
+		{
+			bool flag = middle == null;
+			Vec3d vec3d;
+			if (flag)
+			{
+				vec3d = null;
+			}
+			else
+			{
+				IBlockAccessor blockAccessor = this.entity.World.BlockAccessor;
+				for (int i = 0; i < 5; i++)
+				{
+					int num = this.entity.World.Rand.Next(-1, 2);
+					int num2 = this.entity.World.Rand.Next(-1, 2);
+					Vec3d vec3d2 = middle.AddCopy((float)num2, 0f, (float)num);
+					bool flag2 = blockAccessor.GetBlock(vec3d2.AsBlockPos.Up(1)).Id == 0;
+					if (flag2)
+					{
+						return vec3d2;
+					}
+				}
+				vec3d = middle;
+			}
+			return vec3d;
+		}
 
-        public override bool ShouldExecute()
-        {
-            return base.ShouldExecute() && IntervalUtil.matchesCurrentTime(duringDayTimeFrames, entity.World, offset);
-        }
-        private Vec3d getRandomPosNearby(Vec3d middle)
-        {
-            if (middle == null)
-            {
-                return null;
-            }
-            int tries = 0;
-            var blockAccessor = entity.World.BlockAccessor;
+		// Token: 0x06000094 RID: 148 RVA: 0x000068F4 File Offset: 0x00004AF4
+		public override bool ContinueExecute(float dt)
+		{
+			bool flag = this.workstationPos != null && this.targetReached;
+			if (flag)
+			{
+				Vec3d xyz = this.entity.ServerPos.XYZ;
+				Vec3d targetPos = this.targetPos;
+				bool flag2 = targetPos != null;
+				if (flag2)
+				{
+					double num = (double)xyz.DistanceTo(targetPos);
+					bool flag3 = num < 2.0;
+					if (flag3)
+					{
+						this.FaceWorkstation();
+					}
+				}
+			}
+			return base.ContinueExecute(dt);
+		}
 
-            while (tries < 5)
-            {
-                tries++;
-                int offsetY = entity.World.Rand.Next(-1, 2);
-                int offsetX = entity.World.Rand.Next(-1, 2);
+		// Token: 0x06000095 RID: 149 RVA: 0x00006978 File Offset: 0x00004B78
+		private Vec3d getWorkstationStandingPos(Vec3d workstationCenter)
+		{
+			bool flag = workstationCenter == null;
+			Vec3d vec3d;
+			if (flag)
+			{
+				vec3d = null;
+			}
+			else
+			{
+				IBlockAccessor blockAccessor = this.entity.World.BlockAccessor;
+				BlockPos asBlockPos = workstationCenter.AsBlockPos;
+				Block block = blockAccessor.GetBlock(asBlockPos);
+				BlockFacing blockFacing = BlockFacing.NORTH;
+				bool flag2 = block != null && block.Variant != null;
+				if (flag2)
+				{
+					string text;
+					bool flag3 = block.Variant.TryGetValue("side", out text);
+					if (flag3)
+					{
+						blockFacing = BlockFacing.FromCode(text) ?? BlockFacing.NORTH;
+					}
+					else
+					{
+						bool flag4 = block.Variant.TryGetValue("facing", out text);
+						if (flag4)
+						{
+							blockFacing = BlockFacing.FromCode(text) ?? BlockFacing.NORTH;
+						}
+						else
+						{
+							bool flag5 = block.Variant.TryGetValue("orientation", out text);
+							if (flag5)
+							{
+								blockFacing = BlockFacing.FromCode(text) ?? BlockFacing.NORTH;
+							}
+						}
+					}
+				}
+				BlockFacing opposite = blockFacing.Opposite;
+				Vec3d vec3d2 = workstationCenter.AddCopy((double)opposite.Normalf.X * 1.2, 0.0, (double)opposite.Normalf.Z * 1.2);
+				BlockPos asBlockPos2 = vec3d2.AsBlockPos;
+				bool flag6 = blockAccessor.GetBlock(asBlockPos2.Up(1)).Id == 0 && blockAccessor.GetBlock(asBlockPos2).Id != 0;
+				if (flag6)
+				{
+					vec3d = vec3d2;
+				}
+				else
+				{
+					vec3d = this.getRandomPosNearby(workstationCenter);
+				}
+			}
+			return vec3d;
+		}
 
-                var candidate = middle.AddCopy(offsetX, 0, offsetY);
+		// Token: 0x06000096 RID: 150 RVA: 0x00006AF4 File Offset: 0x00004CF4
+		private void FaceWorkstation()
+		{
+			bool flag = this.workstationPos != null;
+			if (flag)
+			{
+				Vec3d xyz = this.entity.ServerPos.XYZ;
+				Vec3d vec3d = this.workstationPos.ToVec3d().Add(0.5, 0.5, 0.5);
+				double num = vec3d.X - xyz.X;
+				double num2 = vec3d.Z - xyz.Z;
+				float num3 = (float)Math.Atan2(num, num2);
+				this.entity.ServerPos.Yaw = num3;
+				this.entity.Pos.Yaw = num3;
+			}
+		}
 
-                if (blockAccessor.GetBlock(candidate.AsBlockPos.Up()).Id == 0)
-                {
-                    return candidate;
-                }
-            }
-            return middle;
-        }
-    }
+		// Token: 0x04000044 RID: 68
+		private float offset;
+
+		// Token: 0x04000045 RID: 69
+		private BlockPos workstationPos;
+	}
 }

--- a/VSVillage/src/Entity/AITask/AiTaskVillagerSleep.cs
+++ b/VSVillage/src/Entity/AITask/AiTaskVillagerSleep.cs
@@ -1,123 +1,753 @@
-using System;
+﻿using System;
+using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
-using Vintagestory.API.Server;
-using Vintagestory.GameContent;
 
 namespace VsVillage
 {
-    public class AiTaskVillagerSleep : AiTaskBase
-    {
+	// Token: 0x0200001C RID: 28
+	public class AiTaskVillagerSleep : AiTaskBase
+	{
+		// Token: 0x060000C3 RID: 195 RVA: 0x00007AE4 File Offset: 0x00005CE4
+		public AiTaskVillagerSleep(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig)
+			: base(entity, taskConfig, aiConfig)
+		{
+			this.moveSpeed = taskConfig["movespeed"].AsFloat(0.06f);
+			this.offset = (float)entity.World.Rand.Next(taskConfig["minoffset"].AsInt(-50), taskConfig["maxoffset"].AsInt(50)) / 100f;
+			this.pathfinder = new VillagerAStarNew(entity.World.GetCachingBlockAccessor(false, false));
+		}
 
-        BlockEntityVillagerBed bedEntity = null;
+		// Token: 0x060000C4 RID: 196 RVA: 0x00007B7C File Offset: 0x00005D7C
+		public override bool ShouldExecute()
+		{
+			float hourOfDay = this.entity.World.Calendar.HourOfDay;
+			bool flag = !this.ManualTimeCheck(hourOfDay);
+			bool flag2;
+			if (flag)
+			{
+				flag2 = false;
+			}
+			else
+			{
+				bool flag3 = this.isExecuting;
+				if (flag3)
+				{
+					flag2 = true;
+				}
+				else
+				{
+					long elapsedMilliseconds = this.entity.World.ElapsedMilliseconds;
+					bool flag4 = elapsedMilliseconds - this.lastSearchTime > 5000L;
+					bool flag5 = !flag4;
+					if (flag5)
+					{
+						flag2 = false;
+					}
+					else
+					{
+						this.lastSearchTime = elapsedMilliseconds;
+						this.entity.World.Logger.Debug("Sleep: Entity " + this.entity.EntityId.ToString() + " searching for bed...");
+						EntityBehaviorVillager behavior = this.entity.GetBehavior<EntityBehaviorVillager>();
+						Village village = ((behavior != null) ? behavior.Village : null);
+						bool flag6 = village == null;
+						if (flag6)
+						{
+							this.entity.World.Logger.Warning("Sleep: No village found for entity " + this.entity.EntityId.ToString());
+							flag2 = false;
+						}
+						else
+						{
+							BlockPos blockPos = village.FindFreeBed(this.entity.EntityId);
+							bool flag7 = blockPos == null;
+							if (flag7)
+							{
+								this.entity.World.Logger.Warning("Sleep: No free bed found for entity " + this.entity.EntityId.ToString());
+								flag2 = false;
+							}
+							else
+							{
+								this.targetBedPos = blockPos.Copy();
+								this.entity.World.Logger.Notification("Sleep: Entity " + this.entity.EntityId.ToString() + " found bed at " + this.targetBedPos.ToString());
+								Vec3d bedStandingPos = this.GetBedStandingPos(this.targetBedPos.ToVec3d());
+								bool flag8 = bedStandingPos == null;
+								if (flag8)
+								{
+									this.entity.World.Logger.Warning("Sleep: Could not find standing position near bed");
+									this.targetBedPos = null;
+									flag2 = false;
+								}
+								else
+								{
+									this.targetPos = bedStandingPos;
+									flag2 = true;
+								}
+							}
+						}
+					}
+				}
+			}
+			return flag2;
+		}
 
-        bool bedReached;
-        float moveSpeed = 0.03f;
-        long lastCheck;
+		// Token: 0x060000C5 RID: 197 RVA: 0x00007DA0 File Offset: 0x00005FA0
+		public override void StartExecute()
+		{
+			base.StartExecute();
+			this.isExecuting = true;
+			this.entity.World.Logger.Notification("Sleep: StartExecute for entity " + this.entity.EntityId.ToString());
+			bool flag = this.targetPos == null;
+			if (flag)
+			{
+				this.entity.World.Logger.Warning("Sleep: StartExecute but targetPos is null!");
+				this.stuck = true;
+			}
+			else
+			{
+				this.pathfinder.blockAccessor.Begin();
+				this.pathfinder.SetEntityCollisionBox(this.entity);
+				BlockPos startPos = this.pathfinder.GetStartPos(this.entity.ServerPos.XYZ);
+				BlockPos asBlockPos = this.targetPos.AsBlockPos;
+				this.currentPath = this.pathfinder.FindPath(startPos, asBlockPos, 1000);
+				this.pathfinder.blockAccessor.Commit();
+				bool flag2 = this.currentPath != null && this.currentPath.Count > 0;
+				if (flag2)
+				{
+					this.entity.World.Logger.Notification("Sleep: Found path with " + this.currentPath.Count.ToString() + " nodes to bed");
+					this.currentPathIndex = 0;
+					this.stuck = false;
+					this.reachedBed = false;
+					this.lastPosition = this.entity.ServerPos.XYZ.Clone();
+					this.stuckCheckTime = this.entity.World.ElapsedMilliseconds;
+					this.timesStuck = 0;
+				}
+				else
+				{
+					this.entity.World.Logger.Warning("Sleep: No path found to bed at " + this.targetPos.ToString());
+					this.stuck = true;
+				}
+			}
+		}
 
-        float offset;
-        AnimationMetaData sleepAnimMeta;
+		// Token: 0x060000C6 RID: 198 RVA: 0x00007F78 File Offset: 0x00006178
+		public override bool ContinueExecute(float dt)
+		{
+			bool flag = this.targetPos == null || this.stuck || this.currentPath == null;
+			bool flag2;
+			if (flag)
+			{
+				this.entity.World.Logger.Debug(string.Concat(new string[]
+				{
+					"Sleep: ContinueExecute ending - targetPos:",
+					(this.targetPos == null).ToString(),
+					" stuck:",
+					this.stuck.ToString(),
+					" path:",
+					(this.currentPath == null).ToString()
+				}));
+				flag2 = false;
+			}
+			else
+			{
+				float hourOfDay = this.entity.World.Calendar.HourOfDay;
+				bool flag3 = !this.ManualTimeCheck(hourOfDay);
+				if (flag3)
+				{
+					this.entity.World.Logger.Notification("Sleep: Time to wake up! Entity " + this.entity.EntityId.ToString());
+					flag2 = false;
+				}
+				else
+				{
+					bool flag4 = this.reachedBed;
+					if (flag4)
+					{
+						flag2 = this.entity.AnimManager.IsAnimationActive(new string[] { "Lie" });
+					}
+					else
+					{
+						this.CheckIfStuck();
+						bool flag5 = this.currentPathIndex >= this.currentPath.Count;
+						if (flag5)
+						{
+							this.entity.World.Logger.Notification("Sleep: Entity " + this.entity.EntityId.ToString() + " reached end of path, starting sleep");
+							this.StartSleeping();
+							flag2 = true;
+						}
+						else
+						{
+							this.HandlePathTraversal();
+							bool flag6 = this.IsAtBed();
+							if (flag6)
+							{
+								this.entity.World.Logger.Notification("Sleep: Entity " + this.entity.EntityId.ToString() + " at bed, starting sleep");
+								this.StartSleeping();
+								flag2 = true;
+							}
+							else
+							{
+								flag2 = !this.stuck;
+							}
+						}
+					}
+				}
+			}
+			return flag2;
+		}
 
-        public AiTaskVillagerSleep(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig) : base(entity, taskConfig, aiConfig)
-        {
-            if (taskConfig["movespeed"] != null)
-            {
-                moveSpeed = taskConfig["movespeed"].AsFloat(0.03f);
-            }
-            sleepAnimMeta = new AnimationMetaData()
-            {
-                Code = taskConfig["sleepAnimation"].AsString("Sleep").ToLowerInvariant(),
-                Animation = taskConfig["sleepAnimation"].AsString("Sleep").ToLowerInvariant(),
-                AnimationSpeed = taskConfig["sleepAnimationSpeed"].AsFloat(1f)
-            }.Init();
-            offset = ((float)entity.World.Rand.Next(taskConfig["minoffset"].AsInt(-50), taskConfig["maxoffset"].AsInt(50))) / 100;
+		// Token: 0x060000C7 RID: 199 RVA: 0x0000817C File Offset: 0x0000637C
+		public override void FinishExecute(bool cancelled)
+		{
+			base.FinishExecute(cancelled);
+			this.isExecuting = false;
+			this.entity.World.Logger.Debug("Sleep: FinishExecute for entity " + this.entity.EntityId.ToString() + ", cancelled: " + cancelled.ToString());
+			this.entity.Controls.WalkVector.Set(0.0, 0.0, 0.0);
+			this.entity.Controls.StopAllMovement();
+			this.entity.ServerPos.Motion.Set(0.0, 0.0, 0.0);
+			this.CloseAllOpenDoors();
+			bool flag = this.animMeta != null;
+			if (flag)
+			{
+				this.entity.AnimManager.StopAnimation(this.animMeta.Code);
+			}
+			this.entity.AnimManager.StopAnimation("Lie");
+			this.targetPos = null;
+			this.targetBedPos = null;
+			this.currentPath = null;
+			this.currentPathIndex = 0;
+			this.reachedBed = false;
+			this.lastPosition = null;
+			this.timesStuck = 0;
+		}
 
-            bedReached = false;
-        }
+		// Token: 0x060000C8 RID: 200 RVA: 0x000082C4 File Offset: 0x000064C4
+		private void ToggleDoor(bool opened, BlockPos target)
+		{
+			Block block = this.entity.World.BlockAccessor.GetBlock(target);
+			bool flag = block != null && block.Code != null;
+			if (flag)
+			{
+				bool flag2 = block.Code.Path.Contains("door") || block.Code.Path.Contains("gate");
+				if (flag2)
+				{
+					BlockSelection blockSelection = new BlockSelection
+					{
+						Block = block,
+						Position = target,
+						HitPosition = new Vec3d(0.5, 0.5, 0.5),
+						Face = BlockFacing.NORTH
+					};
+					TreeAttribute treeAttribute = new TreeAttribute();
+					treeAttribute.SetBool("opened", opened);
+					try
+					{
+						block.Activate(this.entity.World, new Caller
+						{
+							Entity = this.entity,
+							Type = EnumCallerType.Entity,
+							Pos = this.entity.Pos.XYZ
+						}, blockSelection, treeAttribute);
+					}
+					catch (Exception ex)
+					{
+						this.entity.World.Logger.Error("Sleep: Failed to toggle door: " + ex.Message);
+					}
+				}
+			}
+		}
 
-        public override bool ShouldExecute()
-        {
-            if (lastCheck + 10000 < entity.World.ElapsedMilliseconds)
-            {
-                lastCheck = entity.World.ElapsedMilliseconds;
-                retrieveBed();
-                return bedEntity != null && IntervalUtil.matchesCurrentTime(duringDayTimeFrames, entity.World, offset);
-            }
-            else
-            {
-                return false;
-            }
-        }
+		// Token: 0x060000C9 RID: 201 RVA: 0x0000841C File Offset: 0x0000661C
+		private void HandlePathTraversal()
+		{
+			bool flag = this.currentPath == null || this.currentPathIndex >= this.currentPath.Count;
+			if (!flag)
+			{
+				VillagerPathNode villagerPathNode = this.currentPath[this.currentPathIndex];
+				Vec3d vec3d = villagerPathNode.BlockPos.ToVec3d().Add(0.5, 0.0, 0.5);
+				Vec3d xyz = this.entity.ServerPos.XYZ;
+				double num = xyz.X - vec3d.X;
+				double num2 = xyz.Z - vec3d.Z;
+				double num3 = Math.Sqrt(num * num + num2 * num2);
+				bool flag2 = num3 < 0.5;
+				if (flag2)
+				{
+					this.currentPathIndex++;
+					bool flag3 = this.currentPathIndex < this.currentPath.Count;
+					if (flag3)
+					{
+						VillagerPathNode villagerPathNode2 = this.currentPath[this.currentPathIndex];
+						bool isDoor = villagerPathNode2.IsDoor;
+						if (isDoor)
+						{
+							this.ToggleDoor(true, villagerPathNode2.BlockPos);
+						}
+					}
+					bool isDoor2 = villagerPathNode.IsDoor;
+					if (isDoor2)
+					{
+						BlockPos doorPos = villagerPathNode.BlockPos.Copy();
+						this.entity.World.RegisterCallback(delegate(float dtt)
+						{
+							this.ToggleDoor(false, doorPos);
+						}, 2000);
+					}
+				}
+				bool flag4 = this.currentPathIndex < this.currentPath.Count;
+				if (flag4)
+				{
+					VillagerPathNode villagerPathNode3 = this.currentPath[this.currentPathIndex];
+					Vec3d vec3d2 = villagerPathNode3.BlockPos.ToVec3d().Add(0.5, 0.0, 0.5);
+					Vec3d vec3d3 = vec3d2.Clone().Sub(xyz);
+					vec3d3.Y = 0.0;
+					vec3d3 = vec3d3.Normalize();
+					float num4 = (float)Math.Atan2(vec3d3.X, vec3d3.Z);
+					this.entity.ServerPos.Yaw = num4;
+					double num5 = (double)this.moveSpeed;
+					this.entity.Controls.WalkVector.Set(vec3d3.X * num5, 0.0, vec3d3.Z * num5);
+					bool flag5 = this.animMeta != null && !this.entity.AnimManager.IsAnimationActive(new string[] { this.animMeta.Code });
+					if (flag5)
+					{
+						this.entity.AnimManager.StartAnimation(this.animMeta);
+					}
+				}
+			}
+		}
 
+		// Token: 0x060000CA RID: 202 RVA: 0x000086D4 File Offset: 0x000068D4
+		private void CloseAllOpenDoors()
+		{
+			bool flag = this.currentPath != null;
+			if (flag)
+			{
+				for (int i = 0; i < this.currentPath.Count; i++)
+				{
+					VillagerPathNode villagerPathNode = this.currentPath[i];
+					bool isDoor = villagerPathNode.IsDoor;
+					if (isDoor)
+					{
+						Block block = this.entity.World.BlockAccessor.GetBlock(villagerPathNode.BlockPos);
+						bool flag2 = block != null && block.Code != null && (block.Code.Path.Contains("opened") || block.Code.Path.Contains("open"));
+						if (flag2)
+						{
+							this.ToggleDoor(false, villagerPathNode.BlockPos);
+						}
+					}
+				}
+			}
+		}
 
-        public override void StartExecute()
-        {
-            base.StartExecute();
-            bedReached = false;
-            if (bedEntity != null)
-            {
-                pathTraverser.NavigateTo(bedEntity.Pos.ToVec3d(), moveSpeed, 0.5f, tryGoingToBed, tryGoingToBed, null, true, 999, 0, null);
-                tryGoingToBed();
-            }
-        }
-        public override bool ContinueExecute(float dt)
-        {
-            if (lastCheck + 500 < entity.World.ElapsedMilliseconds && !bedReached)
-            {
-                lastCheck = entity.World.ElapsedMilliseconds;
-                tryGoingToBed();
-            }
-            return IntervalUtil.matchesCurrentTime(duringDayTimeFrames, entity.World) && (bedReached || pathTraverser.Active);
-        }
+		// Token: 0x060000CB RID: 203 RVA: 0x000087AC File Offset: 0x000069AC
+		private bool IsAtBed()
+		{
+			return this.targetPos != null && this.entity.ServerPos.SquareDistanceTo(this.targetPos) < 2.25;
+		}
 
-        public override void FinishExecute(bool cancelled)
-        {
-            pathTraverser.Stop();
-            base.FinishExecute(cancelled);
-            entity.AnimManager.StopAnimation(sleepAnimMeta.Code);
-        }
+		// Token: 0x060000CC RID: 204 RVA: 0x000087F0 File Offset: 0x000069F0
+		private void StartSleeping()
+		{
+			this.entity.Controls.WalkVector.Set(0.0, 0.0, 0.0);
+			this.entity.Controls.StopAllMovement();
+			this.entity.ServerPos.Motion.Set(0.0, 0.0, 0.0);
+			bool flag = this.animMeta != null;
+			if (flag)
+			{
+				this.entity.AnimManager.StopAnimation(this.animMeta.Code);
+			}
+			this.entity.AnimManager.StopAnimation("walk");
+			this.entity.AnimManager.StopAnimation("Walk");
+			this.entity.AnimManager.StopAnimation("balanced-walk");
+			this.entity.AnimManager.StopAnimation("interact");
+			bool flag2 = this.targetBedPos != null;
+			if (flag2)
+			{
+				BlockEntityVillagerBed blockEntity = this.entity.World.BlockAccessor.GetBlockEntity<BlockEntityVillagerBed>(this.targetBedPos);
+				bool flag3 = blockEntity != null;
+				if (flag3)
+				{
+					Vec3d bedSleepPosition = this.GetBedSleepPosition(blockEntity);
+					this.entity.ServerPos.SetPos(bedSleepPosition);
+					this.entity.ServerPos.Yaw = blockEntity.Yaw;
+				}
+				else
+				{
+					this.FaceBed();
+				}
+			}
+			AnimationMetaData animationMetaData = new AnimationMetaData
+			{
+				Code = "Lie",
+				Animation = "Lie",
+				AnimationSpeed = 1f
+			}.Init();
+			this.entity.AnimManager.StartAnimation(animationMetaData);
+			this.reachedBed = true;
+			this.entity.World.Logger.Notification("Sleep: Entity " + this.entity.EntityId.ToString() + " now sleeping at " + ((this.targetBedPos != null) ? this.targetBedPos.ToString() : "unknown"));
+		}
 
-        private void tryGoingToBed()
-        {
-            if (bedEntity != null && entity.ServerPos.SquareDistanceTo(bedEntity.Pos.ToVec3d()) < 3)
-            {
-                entity.ServerPos.SetPos(bedEntity.Pos.ToVec3d().Add(0.5, 0, 0.5));
-                entity.ServerPos.Yaw = bedEntity.Yaw;
-                entity.AnimManager.StopAnimation(animMeta.Code);
-                entity.AnimManager.StartAnimation(sleepAnimMeta);
-                bedReached = true;
-                pathTraverser.Stop();
-            }
-        }
+		// Token: 0x060000CD RID: 205 RVA: 0x00008A08 File Offset: 0x00006C08
+		private void FaceBed()
+		{
+			bool flag = this.targetBedPos != null;
+			if (flag)
+			{
+				Vec3d xyz = this.entity.ServerPos.XYZ;
+				Vec3d vec3d = this.targetBedPos.ToVec3d().Add(0.5, 0.5, 0.5);
+				double num = vec3d.X - xyz.X;
+				double num2 = vec3d.Z - xyz.Z;
+				float num3 = (float)Math.Atan2(num, num2);
+				this.entity.ServerPos.Yaw = num3;
+				this.entity.Pos.Yaw = num3;
+			}
+		}
 
-        private void retrieveBed()
-        {
-            bedEntity = null;
-            var blockAccessor = entity.World.BlockAccessor;
-            var villager = entity.GetBehavior<EntityBehaviorVillager>();
-            var village = villager?.Village;
-            if (village == null) return;
-            var bedPos = villager.Bed;
-            if (bedPos == null)
-            {
-                bedPos = village.FindFreeBed(entity.EntityId);
-                villager.Bed = bedPos;
-            }
-            else
-            {
-                village.Beds.TryGetValue(bedPos, out var bed);
-                if (bed == null || bed.OwnerId != entity.EntityId)
-                {
-                    bedPos = null;
-                    villager.Bed = null;
-                }
-            }
+		// Token: 0x060000CE RID: 206 RVA: 0x00008AB8 File Offset: 0x00006CB8
+		private Vec3d GetBedStandingPos(Vec3d bedCenter)
+		{
+			bool flag = bedCenter == null;
+			Vec3d vec3d;
+			if (flag)
+			{
+				vec3d = null;
+			}
+			else
+			{
+				IBlockAccessor blockAccessor = this.entity.World.BlockAccessor;
+				BlockPos asBlockPos = bedCenter.AsBlockPos;
+				Block block = blockAccessor.GetBlock(asBlockPos);
+				BlockFacing blockFacing = BlockFacing.NORTH;
+				bool flag2 = block != null && block.Variant != null;
+				if (flag2)
+				{
+					string text;
+					bool flag3 = block.Variant.TryGetValue("side", out text);
+					if (flag3)
+					{
+						blockFacing = BlockFacing.FromCode(text) ?? BlockFacing.NORTH;
+					}
+					else
+					{
+						bool flag4 = block.Variant.TryGetValue("facing", out text);
+						if (flag4)
+						{
+							blockFacing = BlockFacing.FromCode(text) ?? BlockFacing.NORTH;
+						}
+						else
+						{
+							bool flag5 = block.Variant.TryGetValue("orientation", out text);
+							if (flag5)
+							{
+								blockFacing = BlockFacing.FromCode(text) ?? BlockFacing.NORTH;
+							}
+						}
+					}
+				}
+				BlockFacing opposite = blockFacing.Opposite;
+				Vec3d vec3d2 = bedCenter.AddCopy((double)opposite.Normalf.X * 1.2, 0.0, (double)opposite.Normalf.Z * 1.2);
+				BlockPos asBlockPos2 = vec3d2.AsBlockPos;
+				bool flag6 = blockAccessor.GetBlock(asBlockPos2.Up(1)).Id == 0;
+				bool flag7 = blockAccessor.GetBlock(asBlockPos2).Id != 0;
+				bool flag8 = flag6 && flag7;
+				if (flag8)
+				{
+					vec3d = vec3d2;
+				}
+				else
+				{
+					vec3d = bedCenter;
+				}
+			}
+			return vec3d;
+		}
 
-            if (bedPos != null)
-            {
-                bedEntity = blockAccessor.GetBlockEntity<BlockEntityVillagerBed>(bedPos);
-            }
-        }
-    }
+		// Token: 0x060000CF RID: 207 RVA: 0x00008C34 File Offset: 0x00006E34
+		private void CheckIfStuck()
+		{
+			long elapsedMilliseconds = this.entity.World.ElapsedMilliseconds;
+			bool flag = elapsedMilliseconds - this.stuckCheckTime < 3000L;
+			if (!flag)
+			{
+				Vec3d xyz = this.entity.ServerPos.XYZ;
+				bool flag2 = this.lastPosition != null;
+				if (flag2)
+				{
+					double num = (double)xyz.DistanceTo(this.lastPosition);
+					bool flag3 = num < 0.5;
+					if (flag3)
+					{
+						this.timesStuck++;
+						this.entity.World.Logger.Warning(string.Concat(new string[]
+						{
+							"Sleep: Entity ",
+							this.entity.EntityId.ToString(),
+							" stuck! (count: ",
+							this.timesStuck.ToString(),
+							")"
+						}));
+						bool flag4 = this.timesStuck <= 3;
+						if (flag4)
+						{
+							long num2 = elapsedMilliseconds - this.lastRepathTime;
+							bool flag5 = num2 > 5000L;
+							if (flag5)
+							{
+								this.AttemptRepath();
+								this.lastRepathTime = elapsedMilliseconds;
+							}
+						}
+						else
+						{
+							bool flag6 = this.timesStuck >= 4;
+							if (flag6)
+							{
+								this.entity.World.Logger.Notification("Sleep: Entity " + this.entity.EntityId.ToString() + " teleporting to safe location");
+								this.TeleportToSafeLocation();
+								this.timesStuck = 0;
+							}
+						}
+					}
+					else
+					{
+						this.timesStuck = 0;
+					}
+				}
+				this.lastPosition = xyz.Clone();
+				this.stuckCheckTime = elapsedMilliseconds;
+			}
+		}
+
+		// Token: 0x060000D0 RID: 208 RVA: 0x00008DD8 File Offset: 0x00006FD8
+		private void AttemptRepath()
+		{
+			bool flag = this.targetPos == null;
+			if (!flag)
+			{
+				this.entity.World.Logger.Debug("Sleep: Entity " + this.entity.EntityId.ToString() + " attempting repath");
+				this.pathfinder.blockAccessor.Begin();
+				this.pathfinder.SetEntityCollisionBox(this.entity);
+				BlockPos startPos = this.pathfinder.GetStartPos(this.entity.ServerPos.XYZ);
+				BlockPos asBlockPos = this.targetPos.AsBlockPos;
+				List<VillagerPathNode> list = this.pathfinder.FindPath(startPos, asBlockPos, 1000);
+				this.pathfinder.blockAccessor.Commit();
+				bool flag2 = list != null && list.Count > 0;
+				if (flag2)
+				{
+					this.entity.World.Logger.Debug("Sleep: Found new path with " + list.Count.ToString() + " nodes");
+					this.currentPath = list;
+					this.currentPathIndex = 0;
+				}
+				else
+				{
+					this.entity.World.Logger.Warning("Sleep: Could not find alternative path");
+				}
+			}
+		}
+
+		// Token: 0x060000D1 RID: 209 RVA: 0x00008F18 File Offset: 0x00007118
+		private bool ManualTimeCheck(float currentHour)
+		{
+			float num = 21.5f + this.offset;
+			float num2 = 6f + this.offset;
+			bool flag = num > num2;
+			bool flag2;
+			if (flag)
+			{
+				flag2 = currentHour >= num || currentHour <= num2;
+			}
+			else
+			{
+				flag2 = currentHour >= num && currentHour <= num2;
+			}
+			return flag2;
+		}
+
+		// Token: 0x060000D2 RID: 210 RVA: 0x00008F70 File Offset: 0x00007170
+		private void TeleportToSafeLocation()
+		{
+			Vec3d vec3d = null;
+			string text = "";
+			bool flag = this.targetPos != null;
+			if (flag)
+			{
+				bool flag2 = this.IsPositionSafe(this.targetPos);
+				if (flag2)
+				{
+					vec3d = this.targetPos;
+					text = "bed";
+				}
+			}
+			bool flag3 = vec3d == null;
+			if (flag3)
+			{
+				EntityBehaviorVillager behavior = this.entity.GetBehavior<EntityBehaviorVillager>();
+				Village village = ((behavior != null) ? behavior.Village : null);
+				bool flag4 = village != null;
+				if (flag4)
+				{
+					BlockPos blockPos = village.FindRandomGatherplace();
+					bool flag5 = blockPos != null;
+					if (flag5)
+					{
+						Vec3d vec3d2 = blockPos.ToVec3d().Add(0.5, 1.0, 0.5);
+						bool flag6 = this.IsPositionSafe(vec3d2);
+						if (flag6)
+						{
+							vec3d = vec3d2;
+							text = "gatherplace";
+						}
+					}
+				}
+			}
+			bool flag7 = vec3d == null;
+			if (flag7)
+			{
+				EntityBehaviorVillager behavior2 = this.entity.GetBehavior<EntityBehaviorVillager>();
+				Village village2 = ((behavior2 != null) ? behavior2.Village : null);
+				bool flag8 = village2 != null && behavior2 != null;
+				if (flag8)
+				{
+					BlockPos blockPos2 = village2.FindFreeWorkstation(this.entity.EntityId, behavior2.Profession);
+					bool flag9 = blockPos2 != null;
+					if (flag9)
+					{
+						Vec3d vec3d3 = blockPos2.ToVec3d().Add(0.5, 1.0, 0.5);
+						bool flag10 = this.IsPositionSafe(vec3d3);
+						if (flag10)
+						{
+							vec3d = vec3d3;
+							text = "workstation";
+						}
+					}
+				}
+			}
+			bool flag11 = vec3d != null;
+			if (flag11)
+			{
+				this.entity.TeleportTo(vec3d);
+				this.entity.World.Logger.Notification(string.Concat(new string[]
+				{
+					"Sleep: Teleported entity ",
+					this.entity.EntityId.ToString(),
+					" to ",
+					text,
+					" at ",
+					vec3d.ToString()
+				}));
+				bool flag12 = text == "bed";
+				if (flag12)
+				{
+					this.StartSleeping();
+				}
+				else
+				{
+					this.AttemptRepath();
+				}
+			}
+			else
+			{
+				this.entity.World.Logger.Warning("Sleep: Entity " + this.entity.EntityId.ToString() + " could not find safe teleport location, giving up");
+				this.stuck = true;
+			}
+		}
+
+		// Token: 0x060000D3 RID: 211 RVA: 0x000091DC File Offset: 0x000073DC
+		private bool IsPositionSafe(Vec3d pos)
+		{
+			bool flag = pos == null;
+			bool flag2;
+			if (flag)
+			{
+				flag2 = false;
+			}
+			else
+			{
+				IBlockAccessor blockAccessor = this.entity.World.BlockAccessor;
+				BlockPos asBlockPos = pos.AsBlockPos;
+				Block block = blockAccessor.GetBlock(asBlockPos);
+				Block block2 = blockAccessor.GetBlock(asBlockPos.UpCopy(1));
+				bool flag3 = block.CollisionBoxes == null || block.CollisionBoxes.Length == 0;
+				bool flag4 = block2.CollisionBoxes == null || block2.CollisionBoxes.Length == 0;
+				Block block3 = blockAccessor.GetBlock(asBlockPos.DownCopy(1));
+				bool flag5 = block3.CollisionBoxes != null && block3.CollisionBoxes.Length != 0;
+				flag2 = flag3 && flag4 && flag5;
+			}
+			return flag2;
+		}
+
+		// Token: 0x060000D4 RID: 212 RVA: 0x00009294 File Offset: 0x00007494
+		private Vec3d GetBedSleepPosition(BlockEntityVillagerBed bed)
+		{
+			string text = bed.Block.Variant["side"];
+			bool flag = text == "north";
+			Cardinal cardinal;
+			if (flag)
+			{
+				cardinal = Cardinal.North;
+			}
+			else
+			{
+				bool flag2 = text == "east";
+				if (flag2)
+				{
+					cardinal = Cardinal.East;
+				}
+				else
+				{
+					bool flag3 = text == "south";
+					if (flag3)
+					{
+						cardinal = Cardinal.South;
+					}
+					else
+					{
+						cardinal = Cardinal.West;
+					}
+				}
+			}
+			return bed.Pos.ToVec3d().Add(0.5, 0.0, 0.5).Add(cardinal.Normalf.Clone().Mul(0.7f));
+		}
+
+		// Token: 0x04000066 RID: 102
+		private float moveSpeed = 0.06f;
+
+		// Token: 0x04000067 RID: 103
+		private float offset;
+
+		// Token: 0x04000068 RID: 104
+		private VillagerAStarNew pathfinder;
+
+		// Token: 0x04000069 RID: 105
+		private List<VillagerPathNode> currentPath;
+
+		// Token: 0x0400006A RID: 106
+		private int currentPathIndex;
+
+		// Token: 0x0400006B RID: 107
+		private bool stuck;
+
+		// Token: 0x0400006C RID: 108
+		private Vec3d targetPos;
+
+		// Token: 0x0400006D RID: 109
+		private BlockPos targetBedPos;
+
+		// Token: 0x0400006E RID: 110
+		private long lastSearchTime;
+
+		// Token: 0x0400006F RID: 111
+		private bool reachedBed;
+
+		// Token: 0x04000070 RID: 112
+		private Vec3d lastPosition;
+
+		// Token: 0x04000071 RID: 113
+		private long stuckCheckTime;
+
+		// Token: 0x04000072 RID: 114
+		private int timesStuck;
+
+		// Token: 0x04000073 RID: 115
+		private long lastRepathTime;
+
+		// Token: 0x04000074 RID: 116
+		private bool isExecuting;
+	}
 }

--- a/VSVillage/src/Entity/AITask/AiTaskVillagerWander.cs
+++ b/VSVillage/src/Entity/AITask/AiTaskVillagerWander.cs
@@ -1,0 +1,482 @@
+﻿using System;
+using System.Collections.Generic;
+using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+
+namespace VsVillage
+{
+	// Token: 0x02000067 RID: 103
+	public class AiTaskVillagerWander : AiTaskBase
+	{
+		// Token: 0x06000271 RID: 625 RVA: 0x000134E0 File Offset: 0x000116E0
+		public AiTaskVillagerWander(EntityAgent entity, JsonObject taskConfig, JsonObject aiConfig)
+			: base(entity, taskConfig, aiConfig)
+		{
+			bool flag = taskConfig["moveSpeed"] != null;
+			if (flag)
+			{
+				this.moveSpeed = taskConfig["moveSpeed"].AsFloat(0.03f);
+			}
+			bool flag2 = taskConfig["wanderRange"] != null;
+			if (flag2)
+			{
+				this.wanderRange = taskConfig["wanderRange"].AsFloat(20f);
+			}
+			bool flag3 = taskConfig["wanderCooldownSeconds"] != null;
+			if (flag3)
+			{
+				this.wanderCooldownMs = (long)taskConfig["wanderCooldownSeconds"].AsInt(10) * 1000L;
+			}
+			bool flag4 = taskConfig["entitySuffix"] != null;
+			if (flag4)
+			{
+				this.requiredEntitySuffix = taskConfig["entitySuffix"].AsString(null);
+			}
+			this.pathfinder = new VillagerAStarNew(entity.World.GetCachingBlockAccessor(false, false));
+			this.lastPosition = null;
+			this.stuckCheckTime = 0L;
+			this.timesStuck = 0;
+			this.lastRepathTime = 0L;
+		}
+
+		// Token: 0x06000272 RID: 626 RVA: 0x00013610 File Offset: 0x00011810
+		public override bool ShouldExecute()
+		{
+			bool flag = !string.IsNullOrEmpty(this.requiredEntitySuffix);
+			if (flag)
+			{
+				bool flag2 = this.entity == null || this.entity.Code == null || this.entity.Code.Path == null || !this.entity.Code.Path.EndsWith(this.requiredEntitySuffix);
+				if (flag2)
+				{
+					return false;
+				}
+			}
+			bool flag3 = this.duringDayTimeFrames != null && this.duringDayTimeFrames.Length != 0;
+			if (flag3)
+			{
+				bool flag4 = !IntervalUtil.matchesCurrentTime(this.duringDayTimeFrames, this.entity.World, 0f);
+				if (flag4)
+				{
+					return false;
+				}
+			}
+			long elapsedMilliseconds = this.entity.World.ElapsedMilliseconds;
+			return elapsedMilliseconds - this.lastWanderTime >= this.wanderCooldownMs && this.entity.World.Rand.NextDouble() <= 0.3;
+		}
+
+		// Token: 0x06000273 RID: 627 RVA: 0x00013720 File Offset: 0x00011920
+		public override void StartExecute()
+		{
+			base.StartExecute();
+			this.lastWanderTime = this.entity.World.ElapsedMilliseconds;
+			BlockPos asBlockPos = this.entity.ServerPos.AsBlockPos;
+			int num = 10;
+			for (int i = 0; i < num; i++)
+			{
+				double num2 = this.entity.World.Rand.NextDouble() * 3.141592653589793 * 2.0;
+				double num3 = this.entity.World.Rand.NextDouble() * (double)this.wanderRange;
+				double num4 = Math.Cos(num2) * num3;
+				double num5 = Math.Sin(num2) * num3;
+				BlockPos blockPos = asBlockPos.AddCopy((int)num4, 0, (int)num5);
+				for (int j = 5; j >= -5; j--)
+				{
+					BlockPos blockPos2 = blockPos.AddCopy(0, j, 0);
+					Block block = this.entity.World.BlockAccessor.GetBlock(blockPos2);
+					Block block2 = this.entity.World.BlockAccessor.GetBlock(blockPos2.UpCopy(1));
+					bool flag = block.SideSolid[BlockFacing.UP.Index] && (block2.CollisionBoxes == null || block2.CollisionBoxes.Length == 0);
+					bool flag2 = flag;
+					if (flag2)
+					{
+						blockPos = blockPos2.UpCopy(1);
+						break;
+					}
+				}
+				this.pathfinder.blockAccessor.Begin();
+				this.pathfinder.SetEntityCollisionBox(this.entity);
+				this.currentPath = this.pathfinder.FindPath(asBlockPos, blockPos, 500);
+				this.pathfinder.blockAccessor.Commit();
+				bool flag3 = this.currentPath != null && this.currentPath.Count > 5;
+				if (flag3)
+				{
+					this.targetPos = blockPos.ToVec3d().Add(0.5, 0.0, 0.5);
+					this.currentPathIndex = 0;
+					this.stuck = false;
+					this.lastPosition = this.entity.ServerPos.XYZ.Clone();
+					this.stuckCheckTime = this.entity.World.ElapsedMilliseconds;
+					this.timesStuck = 0;
+					this.entity.World.Logger.Debug("Villager found wander path with " + this.currentPath.Count.ToString() + " nodes to " + blockPos.ToString());
+					break;
+				}
+			}
+			bool flag4 = this.currentPath == null || this.currentPath.Count <= 5;
+			if (flag4)
+			{
+				this.entity.World.Logger.Debug("Villager could not find valid wander destination after " + num.ToString() + " attempts");
+				this.stuck = true;
+			}
+		}
+
+		// Token: 0x06000274 RID: 628 RVA: 0x00013A14 File Offset: 0x00011C14
+		public override bool ContinueExecute(float dt)
+		{
+			this.CheckIfStuck();
+			bool flag = this.targetPos == null || this.stuck || this.currentPath == null;
+			bool flag2;
+			if (flag)
+			{
+				flag2 = false;
+			}
+			else
+			{
+				bool flag3 = this.duringDayTimeFrames != null && this.duringDayTimeFrames.Length != 0;
+				if (flag3)
+				{
+					bool flag4 = !IntervalUtil.matchesCurrentTime(this.duringDayTimeFrames, this.entity.World, 0f);
+					if (flag4)
+					{
+						this.entity.World.Logger.Debug("Wander: Time window ended, stopping");
+						return false;
+					}
+				}
+				bool flag5 = this.currentPathIndex >= this.currentPath.Count;
+				if (flag5)
+				{
+					this.entity.World.Logger.Debug("Villager reached wander destination");
+					flag2 = false;
+				}
+				else
+				{
+					this.HandlePathTraversal();
+					double num = this.entity.ServerPos.SquareDistanceTo(this.targetPos);
+					flag2 = num > 2.0;
+				}
+			}
+			return flag2;
+		}
+
+		// Token: 0x06000275 RID: 629 RVA: 0x00013B20 File Offset: 0x00011D20
+		public override void FinishExecute(bool cancelled)
+		{
+			base.FinishExecute(cancelled);
+			this.entity.Controls.WalkVector.Set(0.0, 0.0, 0.0);
+			this.entity.Controls.StopAllMovement();
+			bool flag = this.animMeta != null;
+			if (flag)
+			{
+				this.entity.AnimManager.StopAnimation(this.animMeta.Code);
+			}
+			this.entity.ServerPos.Motion.X = 0.0;
+			this.entity.ServerPos.Motion.Z = 0.0;
+			this.CloseAllOpenDoors();
+			this.targetPos = null;
+			this.currentPath = null;
+			this.currentPathIndex = 0;
+			this.lastPosition = null;
+			this.timesStuck = 0;
+		}
+
+		// Token: 0x06000276 RID: 630 RVA: 0x00013C0C File Offset: 0x00011E0C
+		private void ToggleDoor(bool opened, BlockPos target)
+		{
+			Block block = this.entity.World.BlockAccessor.GetBlock(target);
+			bool flag = block != null && block.Code != null;
+			if (flag)
+			{
+				bool flag2 = block.Code.Path.Contains("door") || block.Code.Path.Contains("gate");
+				if (flag2)
+				{
+					BlockSelection blockSelection = new BlockSelection
+					{
+						Block = block,
+						Position = target,
+						HitPosition = new Vec3d(0.5, 0.5, 0.5),
+						Face = BlockFacing.NORTH
+					};
+					TreeAttribute treeAttribute = new TreeAttribute();
+					treeAttribute.SetBool("opened", opened);
+					try
+					{
+						block.Activate(this.entity.World, new Caller
+						{
+							Entity = this.entity,
+							Type = EnumCallerType.Entity,
+							Pos = this.entity.Pos.XYZ
+						}, blockSelection, treeAttribute);
+					}
+					catch (Exception ex)
+					{
+						this.entity.World.Logger.Error("Villager failed to toggle door: " + ex.Message);
+					}
+				}
+			}
+		}
+
+		// Token: 0x06000277 RID: 631 RVA: 0x00013D64 File Offset: 0x00011F64
+		private void CloseAllOpenDoors()
+		{
+			bool flag = this.currentPath != null;
+			if (flag)
+			{
+				for (int i = 0; i < this.currentPath.Count; i++)
+				{
+					VillagerPathNode villagerPathNode = this.currentPath[i];
+					bool isDoor = villagerPathNode.IsDoor;
+					if (isDoor)
+					{
+						Block block = this.entity.World.BlockAccessor.GetBlock(villagerPathNode.BlockPos);
+						bool flag2 = block != null && block.Code != null && (block.Code.Path.Contains("opened") || block.Code.Path.Contains("open"));
+						if (flag2)
+						{
+							this.ToggleDoor(false, villagerPathNode.BlockPos);
+						}
+					}
+				}
+			}
+		}
+
+		// Token: 0x06000278 RID: 632 RVA: 0x00013E3C File Offset: 0x0001203C
+		private void HandlePathTraversal()
+		{
+			bool flag = this.currentPath == null || this.currentPathIndex >= this.currentPath.Count;
+			if (flag)
+			{
+				this.stuck = true;
+			}
+			else
+			{
+				VillagerPathNode villagerPathNode = this.currentPath[this.currentPathIndex];
+				Vec3d vec3d = villagerPathNode.BlockPos.ToVec3d().Add(0.5, 0.0, 0.5);
+				Vec3d xyz = this.entity.ServerPos.XYZ;
+				double num = xyz.X - vec3d.X;
+				double num2 = xyz.Z - vec3d.Z;
+				double num3 = Math.Sqrt(num * num + num2 * num2);
+				bool flag2 = num3 < 0.5;
+				if (flag2)
+				{
+					this.currentPathIndex++;
+					bool flag3 = this.currentPathIndex < this.currentPath.Count;
+					if (flag3)
+					{
+						VillagerPathNode villagerPathNode2 = this.currentPath[this.currentPathIndex];
+						bool isDoor = villagerPathNode2.IsDoor;
+						if (isDoor)
+						{
+							this.entity.World.Logger.Debug("Villager opening door at " + villagerPathNode2.BlockPos.ToString());
+							this.ToggleDoor(true, villagerPathNode2.BlockPos);
+						}
+					}
+					bool isDoor2 = villagerPathNode.IsDoor;
+					if (isDoor2)
+					{
+						this.entity.World.Logger.Debug("Villager closing door at " + villagerPathNode.BlockPos.ToString());
+						BlockPos doorPos = villagerPathNode.BlockPos.Copy();
+						this.entity.World.RegisterCallback(delegate(float dtt)
+						{
+							this.ToggleDoor(false, doorPos);
+						}, 2000);
+					}
+				}
+				bool flag4 = this.currentPathIndex < this.currentPath.Count;
+				if (flag4)
+				{
+					VillagerPathNode villagerPathNode3 = this.currentPath[this.currentPathIndex];
+					Vec3d vec3d2 = villagerPathNode3.BlockPos.ToVec3d().Add(0.5, 0.0, 0.5);
+					Vec3d vec3d3 = vec3d2.Clone().Sub(xyz);
+					vec3d3.Y = 0.0;
+					vec3d3 = vec3d3.Normalize();
+					float num4 = (float)Math.Atan2(vec3d3.X, vec3d3.Z);
+					this.entity.ServerPos.Yaw = num4;
+					double num5 = (double)this.moveSpeed;
+					this.entity.Controls.WalkVector.Set(vec3d3.X * num5, 0.0, vec3d3.Z * num5);
+					bool flag5 = this.animMeta != null && !this.entity.AnimManager.IsAnimationActive(new string[] { this.animMeta.Code });
+					if (flag5)
+					{
+						this.entity.AnimManager.StartAnimation(this.animMeta);
+					}
+				}
+			}
+		}
+
+		// Token: 0x06000279 RID: 633 RVA: 0x00014154 File Offset: 0x00012354
+		private void CheckIfStuck()
+		{
+			long elapsedMilliseconds = this.entity.World.ElapsedMilliseconds;
+			bool flag = elapsedMilliseconds - this.stuckCheckTime < 3000L;
+			if (!flag)
+			{
+				Vec3d xyz = this.entity.ServerPos.XYZ;
+				bool flag2 = this.lastPosition != null;
+				if (flag2)
+				{
+					double num = (double)xyz.DistanceTo(this.lastPosition);
+					bool flag3 = num < 0.5;
+					if (flag3)
+					{
+						this.timesStuck++;
+						this.entity.World.Logger.Warning(string.Concat(new string[]
+						{
+							"Wander: Villager stuck! Distance: ",
+							num.ToString("F2"),
+							" (count: ",
+							this.timesStuck.ToString(),
+							")"
+						}));
+						bool flag4 = this.timesStuck <= 5;
+						if (flag4)
+						{
+							long num2 = elapsedMilliseconds - this.lastRepathTime;
+							bool flag5 = num2 > 5000L;
+							if (flag5)
+							{
+								this.entity.World.Logger.Notification("Wander recovery " + this.timesStuck.ToString() + ": Re-pathing");
+								this.AttemptRepath();
+								this.lastRepathTime = elapsedMilliseconds;
+							}
+						}
+						else
+						{
+							bool flag6 = this.timesStuck >= 6;
+							if (flag6)
+							{
+								this.entity.World.Logger.Notification("Wander recovery FINAL: Teleporting");
+								this.TeleportToRecoveryPosition();
+								this.timesStuck = 0;
+							}
+						}
+					}
+					else
+					{
+						bool flag7 = this.timesStuck > 0;
+						if (flag7)
+						{
+							this.entity.World.Logger.Debug("Wander: Moving again! Distance: " + num.ToString("F2"));
+						}
+						this.timesStuck = 0;
+					}
+				}
+				this.lastPosition = xyz.Clone();
+				this.stuckCheckTime = elapsedMilliseconds;
+			}
+		}
+
+		// Token: 0x0600027A RID: 634 RVA: 0x00014348 File Offset: 0x00012548
+		private void AttemptRepath()
+		{
+			bool flag = this.targetPos == null;
+			if (!flag)
+			{
+				this.entity.World.Logger.Debug("Wander: Finding new path");
+				this.pathfinder.blockAccessor.Begin();
+				this.pathfinder.SetEntityCollisionBox(this.entity);
+				BlockPos startPos = this.pathfinder.GetStartPos(this.entity.ServerPos.XYZ);
+				BlockPos asBlockPos = this.targetPos.AsBlockPos;
+				List<VillagerPathNode> list = this.pathfinder.FindPath(startPos, asBlockPos, 500);
+				this.pathfinder.blockAccessor.Commit();
+				bool flag2 = list != null && list.Count > 0;
+				if (flag2)
+				{
+					this.entity.World.Logger.Notification("Wander: New path with " + list.Count.ToString() + " nodes");
+					this.currentPath = list;
+					this.currentPathIndex = 0;
+					this.stuck = false;
+				}
+				else
+				{
+					this.entity.World.Logger.Warning("Wander: No alternative path found");
+				}
+			}
+		}
+
+		// Token: 0x0600027B RID: 635 RVA: 0x00014478 File Offset: 0x00012678
+		private void TeleportToRecoveryPosition()
+		{
+			Vec3d vec3d = null;
+			bool flag = this.currentPath != null && this.currentPathIndex < this.currentPath.Count;
+			if (flag)
+			{
+				int num = Math.Min(2, this.currentPath.Count - this.currentPathIndex - 1);
+				bool flag2 = num > 0;
+				if (flag2)
+				{
+					VillagerPathNode villagerPathNode = this.currentPath[this.currentPathIndex + num];
+					vec3d = villagerPathNode.BlockPos.ToVec3d().Add(0.5, 0.1, 0.5);
+					this.currentPathIndex += num;
+					this.entity.World.Logger.Notification("Wander: Teleporting " + num.ToString() + " nodes ahead");
+				}
+			}
+			bool flag3 = vec3d == null && this.targetPos != null;
+			if (flag3)
+			{
+				Vec3d xyz = this.entity.ServerPos.XYZ;
+				Vec3d vec3d2 = this.targetPos.Clone().Sub(xyz).Normalize();
+				vec3d = xyz.Add(vec3d2.X * 2.0, 0.5, vec3d2.Z * 2.0);
+				this.entity.World.Logger.Notification("Wander: Teleporting toward target");
+			}
+			bool flag4 = vec3d != null;
+			if (flag4)
+			{
+				IBlockAccessor blockAccessor = this.entity.World.BlockAccessor;
+				BlockPos asBlockPos = vec3d.AsBlockPos;
+				Block block = blockAccessor.GetBlock(asBlockPos);
+				Block block2 = blockAccessor.GetBlock(asBlockPos.UpCopy(1));
+				bool flag5 = block.CollisionBoxes == null || block.CollisionBoxes.Length == 0;
+				bool flag6 = block2.CollisionBoxes == null || block2.CollisionBoxes.Length == 0;
+				bool flag7 = flag5 && flag6;
+				if (flag7)
+				{
+					this.entity.TeleportTo(vec3d);
+					this.entity.World.Logger.Notification("Wander: Teleported to " + vec3d.ToString());
+					this.entity.ServerPos.Motion.Y = 0.1;
+				}
+				else
+				{
+					this.entity.World.Logger.Warning("Wander: Teleport target unsafe");
+					this.stuck = true;
+				}
+			}
+		}
+
+		// Token: 0x04000183 RID: 387
+		private Vec3d targetPos;
+
+		// Token: 0x04000184 RID: 388
+		private float moveSpeed = 0.03f;
+
+		// Token: 0x04000185 RID: 389
+		private float wanderRange = 20f;
+
+		// Token: 0x04000186 RID: 390
+		private long lastWanderTime;
+
+		// Token: 0x04000187 RID: 391
+		private long wanderCooldownMs = 10000L;
+
+		// Token: 0x04000188 RID: 392
+		private string requiredEntitySuffix;
+
+		// Token: 0x04000189 RID: 393
+		private VillagerAStarNew pathfinder;
+
+		// Token: 0x0400018A RID: 394
+		private List<VillagerPathNode> currentPath;
+
+		// Token: 0x0400018B RID: 395
+		private int currentPathIndex;
+
+		// Token: 0x0400018C RID: 396
+		private bool stuck;
+
+		// Token: 0x0400018D RID: 397
+		private Vec3d lastPosition;
+
+		// Token: 0x0400018E RID: 398
+		private long stuckCheckTime;
+
+		// Token: 0x0400018F RID: 399
+		private int timesStuck;
+
+		// Token: 0x04000190 RID: 400
+		private long lastRepathTime;
+	}
+}

--- a/VSVillage/src/Entity/AITask/IntervalUtil.cs
+++ b/VSVillage/src/Entity/AITask/IntervalUtil.cs
@@ -1,22 +1,26 @@
+﻿using System;
 using Vintagestory.API.Common;
 
 namespace VsVillage
 {
-    public class IntervalUtil
-    {
-        public static bool matchesCurrentTime(DayTimeFrame[] dayTimeFrames, IWorldAccessor world, float offset = 0)
-        {
-            bool match = false;
-            if (dayTimeFrames != null)
-            {
-                var hourOfDay = world.Calendar.HourOfDay / world.Calendar.HoursPerDay * 24f;
-                for (int i = 0; !match && i < dayTimeFrames.Length; i++)
-                {
-                    // Add offset in check to artifically randomize start/stop values
-                    match |= dayTimeFrames[i].Matches(hourOfDay + offset);
-                }
-            }
-            return match;
-        }
-    }
+	// Token: 0x0200001F RID: 31
+	public class IntervalUtil
+	{
+		// Token: 0x060000DE RID: 222 RVA: 0x00009474 File Offset: 0x00007674
+		public static bool matchesCurrentTime(DayTimeFrame[] dayTimeFrames, IWorldAccessor world, float offset = 0f)
+		{
+			bool flag = false;
+			if (dayTimeFrames != null)
+			{
+				float num = world.Calendar.HourOfDay / world.Calendar.HoursPerDay * 24f;
+				int num2 = 0;
+				while (!flag && num2 < dayTimeFrames.Length)
+				{
+					flag |= dayTimeFrames[num2].Matches((double)(num + offset));
+					num2++;
+				}
+			}
+			return flag;
+		}
+	}
 }

--- a/VSVillage/src/Entity/Pathfinding/VillagerAStar.cs
+++ b/VSVillage/src/Entity/Pathfinding/VillagerAStar.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
@@ -6,246 +6,300 @@ using Vintagestory.Essentials;
 
 namespace VsVillage
 {
-    public class VillagerAStar
-    {
-        protected ICoreAPI api;
-        protected ICachingBlockAccessor blockAccess;
+	// Token: 0x02000027 RID: 39
+	public class VillagerAStar
+	{
+		// Token: 0x17000021 RID: 33
+		// (get) Token: 0x0600011B RID: 283 RVA: 0x00002C1F File Offset: 0x00000E1F
+		// (set) Token: 0x0600011C RID: 284 RVA: 0x00002C27 File Offset: 0x00000E27
+		public List<string> traversableCodes { get; set; } = new List<string> { "door", "gate", "ladder", "multiblock" };
 
-        public List<string> traversableCodes { get; set; } = new List<string>() { "door", "gate", "ladder", "multiblock" };
+		// Token: 0x17000022 RID: 34
+		// (get) Token: 0x0600011D RID: 285 RVA: 0x00002C30 File Offset: 0x00000E30
+		// (set) Token: 0x0600011E RID: 286 RVA: 0x00002C38 File Offset: 0x00000E38
+		public List<string> climbableCodes { get; set; } = new List<string> { "ladder" };
 
-        public List<string> climbableCodes { get; set; } = new List<string>() { "ladder" };
-        public List<string> steppableCodes { get; set; } = new List<string>() { "stair", "path", "bed-", "farmland", "slab" };
+		// Token: 0x17000023 RID: 35
+		// (get) Token: 0x0600011F RID: 287 RVA: 0x00002C41 File Offset: 0x00000E41
+		// (set) Token: 0x06000120 RID: 288 RVA: 0x00002C49 File Offset: 0x00000E49
+		public List<string> steppableCodes { get; set; } = new List<string> { "stair", "path", "bed-", "farmland", "slab" };
 
-        public int NodesChecked;
+		// Token: 0x06000121 RID: 289 RVA: 0x00009E58 File Offset: 0x00008058
+		public VillagerAStar(ICoreAPI api)
+		{
+			this.api = api;
+			this.blockAccess = api.World.GetCachingBlockAccessor(true, true);
+		}
 
-        public const double centerOffsetX = 0.5;
-        public const double centerOffsetZ = 0.5;
+		// Token: 0x06000122 RID: 290 RVA: 0x00009F2C File Offset: 0x0000812C
+		public List<PathNode> FindPath(BlockPos start, BlockPos end, int maxFallHeight, float stepHeight, int searchDepth = 999, bool allowReachAlmost = true)
+		{
+			this.blockAccess.Begin();
+			this.NodesChecked = 0;
+			PathNode pathNode = new PathNode(start);
+			PathNode pathNode2 = new PathNode(end);
+			this.openSet.Clear();
+			this.closedSet.Clear();
+			this.openSet.Add(pathNode);
+			while (this.openSet.Count > 0)
+			{
+				int nodesChecked = this.NodesChecked;
+				this.NodesChecked = nodesChecked + 1;
+				if (nodesChecked > searchDepth)
+				{
+					return null;
+				}
+				PathNode pathNode3 = this.openSet.RemoveNearest();
+				this.closedSet.Add(pathNode3);
+				if (pathNode3 == pathNode2 || (allowReachAlmost && Math.Abs(pathNode3.X - pathNode2.X) <= 1 && Math.Abs(pathNode3.Z - pathNode2.Z) <= 1 && Math.Abs(pathNode3.Y - pathNode2.Y) <= 2))
+				{
+					return this.retracePath(pathNode, pathNode3);
+				}
+				foreach (PathNode pathNode4 in this.findValidNeighbourNodes(pathNode3, pathNode2, stepHeight, maxFallHeight))
+				{
+					float num = 0f;
+					PathNode pathNode5 = this.openSet.TryFindValue(pathNode4);
+					if (pathNode5 != null)
+					{
+						float num2 = pathNode3.gCost + pathNode3.distanceTo(pathNode4);
+						if (pathNode5.gCost > num2 + 0.0001f && this.traversable(pathNode4, pathNode2, stepHeight, maxFallHeight) && pathNode5.gCost > num2 + num + 0.0001f)
+						{
+							this.UpdateNode(pathNode3, pathNode5, num);
+						}
+					}
+					else if (!this.closedSet.Contains(pathNode4) && this.traversable(pathNode4, pathNode2, stepHeight, maxFallHeight))
+					{
+						this.UpdateNode(pathNode3, pathNode4, num);
+						pathNode4.hCost = pathNode4.distanceTo(pathNode2);
+						this.openSet.Add(pathNode4);
+					}
+				}
+			}
+			return null;
+		}
 
-        public VillagerAStar(ICoreAPI api)
-        {
-            this.api = api;
-            blockAccess = api.World.GetCachingBlockAccessor(true, true);
-        }
+		// Token: 0x06000123 RID: 291 RVA: 0x0000A114 File Offset: 0x00008314
+		protected virtual IEnumerable<PathNode> findValidNeighbourNodes(PathNode nearestNode, PathNode targetNode, float stepHeight, int maxFallHeight)
+		{
+			Block current = this.blockAccess.GetBlock(new BlockPos(nearestNode.X, nearestNode.Y, nearestNode.Z, 0));
+			if (this.climbableCodes.Exists((string code) => current.Code.Path.Contains(code)))
+			{
+				string text = current.Variant["side"];
+				Cardinal cardinal;
+				List<PathNode> list;
+				if (!(text == "east"))
+				{
+					if (!(text == "west"))
+					{
+						if (!(text == "south"))
+						{
+							cardinal = Cardinal.North;
+							list = new List<PathNode>(new PathNode[]
+							{
+								new PathNode(nearestNode, Cardinal.East),
+								new PathNode(nearestNode, Cardinal.South),
+								new PathNode(nearestNode, Cardinal.West)
+							});
+						}
+						else
+						{
+							cardinal = Cardinal.South;
+							list = new List<PathNode>(new PathNode[]
+							{
+								new PathNode(nearestNode, Cardinal.North),
+								new PathNode(nearestNode, Cardinal.East),
+								new PathNode(nearestNode, Cardinal.West)
+							});
+						}
+					}
+					else
+					{
+						cardinal = Cardinal.West;
+						list = new List<PathNode>(new PathNode[]
+						{
+							new PathNode(nearestNode, Cardinal.North),
+							new PathNode(nearestNode, Cardinal.East),
+							new PathNode(nearestNode, Cardinal.South)
+						});
+					}
+				}
+				else
+				{
+					cardinal = Cardinal.East;
+					list = new List<PathNode>(new PathNode[]
+					{
+						new PathNode(nearestNode, Cardinal.North),
+						new PathNode(nearestNode, Cardinal.South),
+						new PathNode(nearestNode, Cardinal.West)
+					});
+				}
+				int i = 1;
+				while (this.traversableCodes.Exists((string code) => this.blockAccess.GetBlock(new BlockPos(nearestNode.X, nearestNode.Y + i, nearestNode.Z, 0)).Code.Path.Contains(code)))
+				{
+					int j = i;
+					i = j + 1;
+				}
+				PathNode pathNode = new PathNode(nearestNode, cardinal);
+				pathNode.Y += i;
+				list.Add(pathNode);
+				return list;
+			}
+			return new PathNode[]
+			{
+				new PathNode(nearestNode, Cardinal.North),
+				new PathNode(nearestNode, Cardinal.East),
+				new PathNode(nearestNode, Cardinal.South),
+				new PathNode(nearestNode, Cardinal.West)
+			};
+		}
 
-        public PathNodeSet openSet = new PathNodeSet();
-        public HashSet<PathNode> closedSet = new HashSet<PathNode>();
+		// Token: 0x06000124 RID: 292 RVA: 0x00002C52 File Offset: 0x00000E52
+		private void UpdateNode(PathNode nearestNode, PathNode neighbourNode, float extraCost)
+		{
+			neighbourNode.gCost = nearestNode.gCost + nearestNode.distanceTo(neighbourNode) + extraCost;
+			neighbourNode.Parent = nearestNode;
+			neighbourNode.pathLength = nearestNode.pathLength + 1;
+		}
 
-        public List<PathNode> FindPath(BlockPos start, BlockPos end, int maxFallHeight, float stepHeight, int searchDepth = 999, bool allowReachAlmost = true)
-        {
-            blockAccess.Begin();
+		// Token: 0x06000125 RID: 293 RVA: 0x0000A410 File Offset: 0x00008610
+		protected virtual bool traversable(PathNode node, PathNode target, float stepHeight, int maxFallHeight)
+		{
+			if (target.X == node.X && target.Z == node.Z && target.Y == node.Y)
+			{
+				return true;
+			}
+			if (this.traversable(this.blockAccess.GetBlock(new BlockPos(node.X, node.Y, node.Z, 0))) && this.traversable(this.blockAccess.GetBlock(new BlockPos(node.X, node.Y + 1, node.Z, 0))))
+			{
+				while (0 <= maxFallHeight)
+				{
+					Block block = this.blockAccess.GetBlock(new BlockPos(node.X, node.Y - 1, node.Z, 0));
+					if (this.canStep(block))
+					{
+						return true;
+					}
+					if (!this.traversable(block))
+					{
+						return false;
+					}
+					node.Y--;
+					maxFallHeight--;
+				}
+				while (this.climbableCodes.Exists((string code) => this.blockAccess.GetBlock(new BlockPos(node.X, node.Y, node.Z, 0)).Code.Path.Contains(code)))
+				{
+					Block block2 = this.blockAccess.GetBlock(new BlockPos(node.X, node.Y - 1, node.Z, 0));
+					if (this.canStep(block2))
+					{
+						return true;
+					}
+					node.Y--;
+				}
+			}
+			else
+			{
+				while (1f < stepHeight)
+				{
+					node.Y++;
+					if (this.canStep(this.blockAccess.GetBlock(new BlockPos(node.X, node.Y - 1, node.Z, 0))) && this.traversable(this.blockAccess.GetBlock(new BlockPos(node.X, node.Y, node.Z, 0))) && this.traversable(this.blockAccess.GetBlock(new BlockPos(node.X, node.Y + 1, node.Z, 0))))
+					{
+						return true;
+					}
+					stepHeight -= 1f;
+				}
+			}
+			return false;
+		}
 
-            NodesChecked = 0;
+		// Token: 0x06000126 RID: 294 RVA: 0x0000A6A4 File Offset: 0x000088A4
+		public BlockPos GetStartPos(Vec3d startPos)
+		{
+			BlockPos asBlockPos = startPos.AsBlockPos;
+			Block block = this.blockAccess.GetBlock(asBlockPos);
+			if (this.traversable(block))
+			{
+				return asBlockPos;
+			}
+			if (this.getDecimalPart(startPos.Z) < 0.5 && this.traversable(this.blockAccess.GetBlock(asBlockPos.NorthCopy(1))))
+			{
+				return asBlockPos.NorthCopy(1);
+			}
+			if (this.getDecimalPart(startPos.Z) > 0.5 && this.traversable(this.blockAccess.GetBlock(asBlockPos.SouthCopy(1))))
+			{
+				return asBlockPos.SouthCopy(1);
+			}
+			if (this.getDecimalPart(startPos.X) < 0.5 && this.traversable(this.blockAccess.GetBlock(asBlockPos.West())))
+			{
+				return asBlockPos;
+			}
+			if (this.getDecimalPart(startPos.X) > 0.5 && this.traversable(this.blockAccess.GetBlock(asBlockPos.East())))
+			{
+				return asBlockPos;
+			}
+			if (this.getDecimalPart(startPos.Z) < 0.5 && this.traversable(this.blockAccess.GetBlock(asBlockPos.NorthCopy(1))))
+			{
+				return asBlockPos.NorthCopy(1);
+			}
+			if (this.getDecimalPart(startPos.Z) > 0.5 && this.traversable(this.blockAccess.GetBlock(asBlockPos.SouthCopy(1))))
+			{
+				return asBlockPos.SouthCopy(1);
+			}
+			return startPos.AsBlockPos;
+		}
 
-            PathNode startNode = new PathNode(start);
-            PathNode targetNode = new PathNode(end);
+		// Token: 0x06000127 RID: 295 RVA: 0x00002C7F File Offset: 0x00000E7F
+		private double getDecimalPart(double number)
+		{
+			return number - Math.Truncate(number);
+		}
 
-            openSet.Clear();
-            closedSet.Clear();
+		// Token: 0x06000128 RID: 296 RVA: 0x0000A820 File Offset: 0x00008A20
+		protected virtual bool canStep(Block belowBlock)
+		{
+			return belowBlock.SideSolid[BlockFacing.UP.Index] || this.steppableCodes.Exists((string code) => belowBlock.Code.Path.Contains(code));
+		}
 
-            openSet.Add(startNode);
+		// Token: 0x06000129 RID: 297 RVA: 0x0000A870 File Offset: 0x00008A70
+		protected virtual bool traversable(Block block)
+		{
+			return block.CollisionBoxes == null || block.CollisionBoxes.Length == 0 || this.traversableCodes.Exists((string code) => block.Code.Path.Contains(code));
+		}
 
-            while (openSet.Count > 0)
-            {
-                if (NodesChecked++ > searchDepth) return null;
+		// Token: 0x0600012A RID: 298 RVA: 0x0000A8C0 File Offset: 0x00008AC0
+		private List<PathNode> retracePath(PathNode startNode, PathNode endNode)
+		{
+			int pathLength = endNode.pathLength;
+			List<PathNode> list = new List<PathNode>(pathLength + 1);
+			for (int i = 0; i < pathLength + 1; i++)
+			{
+				list.Add(null);
+			}
+			PathNode pathNode = endNode;
+			for (int j = pathLength; j >= 0; j--)
+			{
+				list[j] = pathNode;
+				pathNode = pathNode.Parent;
+			}
+			return list;
+		}
 
-                PathNode nearestNode = openSet.RemoveNearest();
-                closedSet.Add(nearestNode);
+		// Token: 0x0400008A RID: 138
+		protected ICoreAPI api;
 
-                if (nearestNode == targetNode || (allowReachAlmost && Math.Abs(nearestNode.X - targetNode.X) <= 1 && Math.Abs(nearestNode.Z - targetNode.Z) <= 1 && Math.Abs(nearestNode.Y - targetNode.Y) <= 2))
-                {
-                    return retracePath(startNode, nearestNode);
-                }
+		// Token: 0x0400008B RID: 139
+		protected ICachingBlockAccessor blockAccess;
 
-                foreach (var neighbourNode in findValidNeighbourNodes(nearestNode, targetNode, stepHeight, maxFallHeight))
-                {
-                    float extraCost = 0;
-                    PathNode existingNeighbourNode = openSet.TryFindValue(neighbourNode);
-                    if (!(existingNeighbourNode is null))   // we have to do a null check using "is null" due to foibles in PathNode.Equals()
-                    {
-                        // if it is already in openSet, update the gCost and parent if this nearestNode gives a shorter route to it
-                        float baseCostToNeighbour = nearestNode.gCost + nearestNode.distanceTo(neighbourNode);
-                        if (existingNeighbourNode.gCost > baseCostToNeighbour + 0.0001f)
-                        {
-                            if (traversable(neighbourNode, targetNode, stepHeight, maxFallHeight) && existingNeighbourNode.gCost > baseCostToNeighbour + extraCost + 0.0001f)
-                            {
-                                UpdateNode(nearestNode, existingNeighbourNode, extraCost);
-                            }
-                        }
-                    }
-                    else if (!closedSet.Contains(neighbourNode))
-                    {
-                        if (traversable(neighbourNode, targetNode, stepHeight, maxFallHeight))
-                        {
-                            UpdateNode(nearestNode, neighbourNode, extraCost);
-                            neighbourNode.hCost = neighbourNode.distanceTo(targetNode);
-                            openSet.Add(neighbourNode);
-                        }
-                    }
-                }
-            }
+		// Token: 0x0400008F RID: 143
+		public int NodesChecked;
 
-            return null;
-        }
+		// Token: 0x04000090 RID: 144
+		public const double centerOffsetX = 0.5;
 
-        protected virtual IEnumerable<PathNode> findValidNeighbourNodes(PathNode nearestNode, PathNode targetNode, float stepHeight, int maxFallHeight)
-        {
-            Block current = blockAccess.GetBlock(new BlockPos(nearestNode.X, nearestNode.Y, nearestNode.Z, 0));
-            if (climbableCodes.Exists(code => current.Code.Path.Contains(code)))
-            {
-                Cardinal climbableCard;
-                List<PathNode> neighbourNodes;
-                switch (current.Variant["side"])
-                {
-                    case "east":
-                        climbableCard = Cardinal.East;
-                        neighbourNodes = new List<PathNode>(new PathNode[] { new PathNode(nearestNode, Cardinal.North), new PathNode(nearestNode, Cardinal.South), new PathNode(nearestNode, Cardinal.West) });
-                        break;
-                    case "west":
-                        climbableCard = Cardinal.West;
-                        neighbourNodes = new List<PathNode>(new PathNode[] { new PathNode(nearestNode, Cardinal.North), new PathNode(nearestNode, Cardinal.East), new PathNode(nearestNode, Cardinal.South) });
-                        break;
-                    case "south":
-                        climbableCard = Cardinal.South;
-                        neighbourNodes = new List<PathNode>(new PathNode[] { new PathNode(nearestNode, Cardinal.North), new PathNode(nearestNode, Cardinal.East), new PathNode(nearestNode, Cardinal.West) });
-                        break;
-                    default:
-                        climbableCard = Cardinal.North;
-                        neighbourNodes = new List<PathNode>(new PathNode[] { new PathNode(nearestNode, Cardinal.East), new PathNode(nearestNode, Cardinal.South), new PathNode(nearestNode, Cardinal.West) });
-                        break;
-                }
-                int i = 1;
-                while (traversableCodes.Exists(code => blockAccess.GetBlock(new BlockPos(nearestNode.X, nearestNode.Y + i, nearestNode.Z, 0)).Code.Path.Contains(code)))
-                {
-                    i++;
-                }
-                var climbableNode = new PathNode(nearestNode, climbableCard);
-                climbableNode.Y += i;
-                neighbourNodes.Add(climbableNode);
-                return neighbourNodes;
-            }
-            else
-            {
-                return new PathNode[] { new PathNode(nearestNode, Cardinal.North), new PathNode(nearestNode, Cardinal.East), new PathNode(nearestNode, Cardinal.South), new PathNode(nearestNode, Cardinal.West) };
-            }
-        }
+		// Token: 0x04000091 RID: 145
+		public const double centerOffsetZ = 0.5;
 
+		// Token: 0x04000092 RID: 146
+		public PathNodeSet openSet = new PathNodeSet();
 
-
-        /// <summary>
-        /// Actually now only sets fields in neighbourNode as appropriate.  The calling code must add this to openSet if necessary.
-        /// </summary>
-        private void UpdateNode(PathNode nearestNode, PathNode neighbourNode, float extraCost)
-        {
-            neighbourNode.gCost = nearestNode.gCost + nearestNode.distanceTo(neighbourNode) + extraCost;
-            neighbourNode.Parent = nearestNode;
-            neighbourNode.pathLength = nearestNode.pathLength + 1;
-        }
-
-        protected virtual bool traversable(PathNode node, PathNode target, float stepHeight, int maxFallHeight)
-        {
-            if (target.X == node.X && target.Z == node.Z && target.Y == node.Y) { return true; }
-            if (traversable(blockAccess.GetBlock(new BlockPos(node.X, node.Y, node.Z, 0)))
-                && traversable(blockAccess.GetBlock(new BlockPos(node.X, node.Y + 1, node.Z, 0))))
-            {
-                for (; 0 <= maxFallHeight; maxFallHeight--)
-                {
-                    Block belowBlock = blockAccess.GetBlock(new BlockPos(node.X, node.Y - 1, node.Z, 0));
-                    if (canStep(belowBlock)) { return true; }
-                    if (!traversable(belowBlock)) { return false; };
-                    node.Y--;
-                }
-                while (climbableCodes.Exists(code => blockAccess.GetBlock(new BlockPos(node.X, node.Y, node.Z, 0)).Code.Path.Contains(code)))
-                {
-                    Block belowBlock = blockAccess.GetBlock(new BlockPos(node.X, node.Y - 1, node.Z, 0));
-                    if (canStep(belowBlock)) { return true; }
-                    node.Y--;
-                }
-            }
-            else
-            {
-                for (; 1f < stepHeight; stepHeight--)
-                {
-                    node.Y++;
-                    if (canStep(blockAccess.GetBlock(new BlockPos(node.X, node.Y - 1, node.Z, 0))) && traversable(blockAccess.GetBlock(new BlockPos(node.X, node.Y, node.Z, 0))) && traversable(blockAccess.GetBlock(new BlockPos(node.X, node.Y + 1, node.Z, 0))))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        public BlockPos GetStartPos(Vec3d startPos)
-        {
-            var result = startPos.AsBlockPos;
-            var startBlock = blockAccess.GetBlock(result);
-            if (traversable(startBlock))
-            {
-                return result;
-            }
-
-            if (getDecimalPart(startPos.Z) < 0.5 && traversable(blockAccess.GetBlock(result.NorthCopy())))
-            {
-                return result.NorthCopy();
-            }
-
-            if (getDecimalPart(startPos.Z) > 0.5 && traversable(blockAccess.GetBlock(result.SouthCopy())))
-            {
-                return result.SouthCopy();
-            }
-
-            if (getDecimalPart(startPos.X) < 0.5 && traversable(blockAccess.GetBlock(result.West())))
-            {
-                return result;
-            }
-
-            if (getDecimalPart(startPos.X) > 0.5 && traversable(blockAccess.GetBlock(result.East())))
-            {
-                return result;
-            }
-
-            if (getDecimalPart(startPos.Z) < 0.5 && traversable(blockAccess.GetBlock(result.NorthCopy())))
-            {
-                return result.NorthCopy();
-            }
-
-            if (getDecimalPart(startPos.Z) > 0.5 && traversable(blockAccess.GetBlock(result.SouthCopy())))
-            {
-                return result.SouthCopy();
-            }
-
-            return startPos.AsBlockPos;
-        }
-
-        private double getDecimalPart(double number)
-        {
-            return number - Math.Truncate(number);
-        }
-
-        protected virtual bool canStep(Block belowBlock)
-        {
-            return belowBlock.SideSolid[BlockFacing.UP.Index] || steppableCodes.Exists(code => belowBlock.Code.Path.Contains(code));
-        }
-
-        protected virtual bool traversable(Block block)
-        {
-            return block.CollisionBoxes == null || block.CollisionBoxes.Length == 0 || traversableCodes.Exists(code => block.Code.Path.Contains(code));
-        }
-
-        List<PathNode> retracePath(PathNode startNode, PathNode endNode)
-        {
-            int length = endNode.pathLength;
-            List<PathNode> path = new List<PathNode>(length + 1);
-            for (int i = 0; i < length + 1; i++) path.Add(null);  // pre-fill the path with dummy values to achieve the required Count, needed for assignment to path[i] later
-            PathNode currentNode = endNode;
-
-            for (int i = length; i >= 0; i--)
-            {
-                path[i] = currentNode;
-                currentNode = currentNode.Parent;
-            }
-
-            return path;
-        }
-    }
+		// Token: 0x04000093 RID: 147
+		public HashSet<PathNode> closedSet = new HashSet<PathNode>();
+	}
 }

--- a/VSVillage/src/Entity/Pathfinding/VillagerAStarNew.cs
+++ b/VSVillage/src/Entity/Pathfinding/VillagerAStarNew.cs
@@ -1,177 +1,410 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
-using Vintagestory.API.Util;
 
 namespace VsVillage
 {
-    public class VillagerAStarNew
-    {
-        public List<string> traversableCodes = ["door", "gate", "ladder", "multiblock"];
-        public List<string> doorCodes = ["door", "gate", "multiblock"];
-        public List<string> climbableCodes = ["ladder"];
-        public List<string> steppableCodes = ["stair", "path", "bed-", "farmland", "slab"];
-        public ICachingBlockAccessor blockAccessor;
-        public const float stepHeight = 1.5f;
-        public const int maxFallHeight = 5;
+	// Token: 0x0200002D RID: 45
+	public class VillagerAStarNew
+	{
+		// Token: 0x06000135 RID: 309 RVA: 0x0000A9DC File Offset: 0x00008BDC
+		public VillagerAStarNew(ICachingBlockAccessor blockAccessor)
+		{
+			this.blockAccessor = blockAccessor;
+			this.collTester = new CollisionTester();
+			this.traversableCodes = new List<string> { "door", "gate", "ladder", "multiblock" };
+			this.doorCodes = new List<string> { "door", "gate", "multiblock" };
+			this.climbableCodes = new List<string> { "ladder" };
+			this.steppableCodes = new List<string> { "stair", "path", "bed-", "farmland", "furrowedland", "slab", "carpet" };
+			this.tmpVec = new Vec3d();
+			this.tmpPos = new BlockPos();
+		}
 
-        public VillagerAStarNew(ICachingBlockAccessor blockAccessor)
-        {
-            this.blockAccessor = blockAccessor;
-        }
+		// Token: 0x06000136 RID: 310 RVA: 0x0000AB40 File Offset: 0x00008D40
+		public List<VillagerPathNode> FindPath(BlockPos start, BlockPos end, int searchDepth = 1000)
+		{
+			bool flag = start == null || end == null;
+			bool flag2 = flag;
+			bool flag3 = flag2;
+			List<VillagerPathNode> list;
+			if (flag3)
+			{
+				list = null;
+			}
+			else
+			{
+				this.centerOffsetX = 0.3 + new Random().NextDouble() * 0.4;
+				this.centerOffsetZ = 0.3 + new Random().NextDouble() * 0.4;
+				SortedSet<VillagerPathNode> sortedSet = new SortedSet<VillagerPathNode>();
+				HashSet<VillagerPathNode> hashSet = new HashSet<VillagerPathNode>();
+				VillagerPathNode villagerPathNode = new VillagerPathNode(start, end, this.isDoor(this.blockAccessor.GetBlock(start)));
+				sortedSet.Add(villagerPathNode);
+				int num = 0;
+				while (num < searchDepth && sortedSet.Count > 0)
+				{
+					num++;
+					VillagerPathNode min = sortedSet.Min;
+					sortedSet.Remove(min);
+					hashSet.Add(min);
+					bool flag4 = min.BlockPos.X == end.X && min.BlockPos.Z == end.Z && Math.Abs(min.BlockPos.Y - end.Y) <= 1;
+					bool flag5 = flag4;
+					bool flag6 = flag5;
+					bool flag7 = flag6;
+					if (flag7)
+					{
+						return min.RetracePath();
+					}
+					foreach (Cardinal cardinal in Cardinal.ALL)
+					{
+						VillagerPathNode villagerPathNode2 = new VillagerPathNode(min, cardinal);
+						bool flag8 = hashSet.Contains(villagerPathNode2);
+						bool flag9 = !flag8;
+						bool flag10 = flag9;
+						if (flag10)
+						{
+							float num2 = 0f;
+							bool flag11 = !this.traversable(villagerPathNode2, end, cardinal, ref num2);
+							bool flag12 = !flag11;
+							bool flag13 = flag12;
+							if (flag13)
+							{
+								villagerPathNode2.SetGCostFromParent(min, num2);
+								villagerPathNode2.Init(end, this.isDoor(this.blockAccessor.GetBlock(villagerPathNode2.BlockPos)));
+								VillagerPathNode villagerPathNode3 = null;
+								foreach (VillagerPathNode villagerPathNode4 in sortedSet)
+								{
+									bool flag14 = villagerPathNode4.BlockPos.Equals(villagerPathNode2.BlockPos);
+									bool flag15 = flag14;
+									bool flag16 = flag15;
+									if (flag16)
+									{
+										villagerPathNode3 = villagerPathNode4;
+										break;
+									}
+								}
+								bool flag17 = villagerPathNode3 != null;
+								bool flag18 = flag17;
+								bool flag19 = flag18;
+								if (flag19)
+								{
+									bool flag20 = villagerPathNode2.gCost < villagerPathNode3.gCost - 0.0001f;
+									bool flag21 = flag20;
+									bool flag22 = flag21;
+									if (flag22)
+									{
+										sortedSet.Remove(villagerPathNode3);
+										sortedSet.Add(villagerPathNode2);
+									}
+								}
+								else
+								{
+									sortedSet.Add(villagerPathNode2);
+								}
+							}
+						}
+					}
+				}
+				list = null;
+			}
+			return list;
+		}
 
-        public List<VillagerPathNode> FindPath(BlockPos start, BlockPos end, int searchDepth = 1000)
-        {
-            if (start == null || end == null) return null;
-            var reachableNodes = new SortedSet<VillagerPathNode>([new VillagerPathNode(start, end, isDoor(blockAccessor.GetBlock(start)))]);
-            var visitedNodes = new HashSet<VillagerPathNode>();
-            for (int i = 0; i < searchDepth && reachableNodes.Count > 0; i++)
-            {
-                var currentNode = reachableNodes.Min;
-                if (currentNode.BlockPos.Equals(end))
-                {
-                    return currentNode.RetracePath();
-                }
-                reachableNodes.Remove(currentNode);
-                visitedNodes.Add(currentNode);
+		// Token: 0x06000137 RID: 311 RVA: 0x0000AE24 File Offset: 0x00009024
+		private bool isDoor(Block block)
+		{
+			bool flag = block == null || block.Code == null;
+			bool flag2 = flag;
+			bool flag3 = flag2;
+			bool flag4;
+			if (flag3)
+			{
+				flag4 = false;
+			}
+			else
+			{
+				foreach (string text in this.doorCodes)
+				{
+					bool flag5 = block.Code.Path.Contains(text);
+					bool flag6 = flag5;
+					bool flag7 = flag6;
+					if (flag7)
+					{
+						return true;
+					}
+				}
+				flag4 = false;
+			}
+			return flag4;
+		}
 
-                findValidNeighbourNodes(currentNode)
-                    .Where(node => traversable(node, end) && !visitedNodes.Contains(node))
-                    .Foreach(node => reachableNodes.Add(node));
-            }
-            return null;
-        }
+		// Token: 0x06000138 RID: 312 RVA: 0x0000AEC8 File Offset: 0x000090C8
+		public BlockPos GetStartPos(Vec3d startPos)
+		{
+			BlockPos asBlockPos = startPos.AsBlockPos;
+			this.tmpVec.Set(startPos.X, startPos.Y, startPos.Z);
+			bool flag = !this.collTester.IsColliding(this.blockAccessor, this.entityCollBox, this.tmpVec, false);
+			bool flag2 = flag;
+			bool flag3 = flag2;
+			BlockPos blockPos;
+			if (flag3)
+			{
+				blockPos = asBlockPos;
+			}
+			else
+			{
+				double num = startPos.X - Math.Truncate(startPos.X);
+				double num2 = startPos.Z - Math.Truncate(startPos.Z);
+				BlockPos[] array = new BlockPos[]
+				{
+					asBlockPos.NorthCopy(1),
+					asBlockPos.SouthCopy(1),
+					asBlockPos.WestCopy(1),
+					asBlockPos.EastCopy(1)
+				};
+				foreach (BlockPos blockPos2 in array)
+				{
+					this.tmpVec.Set((double)blockPos2.X + 0.5, (double)blockPos2.Y, (double)blockPos2.Z + 0.5);
+					bool flag4 = !this.collTester.IsColliding(this.blockAccessor, this.entityCollBox, this.tmpVec, false);
+					bool flag5 = flag4;
+					bool flag6 = flag5;
+					if (flag6)
+					{
+						return blockPos2;
+					}
+				}
+				blockPos = startPos.AsBlockPos;
+			}
+			return blockPos;
+		}
 
-        private IEnumerable<VillagerPathNode> findValidNeighbourNodes(VillagerPathNode nearestNode)
-        {
-            Block current = blockAccessor.GetBlock(nearestNode.BlockPos);
-            VillagerPathNode[] neighbours = [new VillagerPathNode(nearestNode, Cardinal.North), new VillagerPathNode(nearestNode, Cardinal.East), new VillagerPathNode(nearestNode, Cardinal.South), new VillagerPathNode(nearestNode, Cardinal.West)];
-            if (climbableCodes.Exists(current.Code.Path.Contains))
-            {
-                var climbableNode = current.Variant["side"] switch
-                {
-                    "north" => neighbours[0],
-                    "east" => neighbours[1],
-                    "south" => neighbours[2],
-                    _ => neighbours[3]
-                };
-                int i = 1;
-                while (traversableCodes.Exists(code => blockAccessor.GetBlock(nearestNode.BlockPos.UpCopy(i)).Code.Path.Contains(code)))
-                {
-                    i++;
-                }
-                climbableNode.BlockPos.Y += i;
-            }
+		// Token: 0x06000139 RID: 313 RVA: 0x0000B02C File Offset: 0x0000922C
+		protected virtual bool traversable(VillagerPathNode node, BlockPos target, Cardinal fromDir, ref float extraCost)
+		{
+			bool flag = node.BlockPos.X == target.X && node.BlockPos.Z == target.Z;
+			bool flag2 = Math.Abs(node.BlockPos.Y - target.Y) <= 1;
+			bool flag3 = flag && flag2;
+			bool flag4 = flag3;
+			bool flag5 = flag4;
+			bool flag6;
+			if (flag5)
+			{
+				flag6 = true;
+			}
+			else
+			{
+				this.tmpVec.Set((double)node.BlockPos.X + this.centerOffsetX, (double)node.BlockPos.Y, (double)node.BlockPos.Z + this.centerOffsetZ);
+				this.tmpPos.Set(node.BlockPos.X, node.BlockPos.Y, node.BlockPos.Z);
+				bool flag7 = !this.collTester.IsColliding(this.blockAccessor, this.entityCollBox, this.tmpVec, false);
+				bool flag8 = flag7;
+				bool flag9 = flag8;
+				if (flag9)
+				{
+					int i = 0;
+					while (i <= 5)
+					{
+						this.tmpPos.Set(node.BlockPos.X, node.BlockPos.Y - 1, node.BlockPos.Z);
+						Block block = this.blockAccessor.GetBlock(this.tmpPos);
+						bool flag10 = !block.CanStep;
+						bool flag11 = flag10;
+						bool flag12 = flag11;
+						if (flag12)
+						{
+							return false;
+						}
+						float traversalCost = block.GetTraversalCost(this.tmpPos, EnumAICreatureType.Humanoid);
+						bool flag13 = traversalCost > 10000f;
+						bool flag14 = flag13;
+						bool flag15 = flag14;
+						if (flag15)
+						{
+							return false;
+						}
+						Cuboidf[] collisionBoxes = block.GetCollisionBoxes(this.blockAccessor, this.tmpPos);
+						bool flag16 = collisionBoxes != null && collisionBoxes.Length != 0;
+						bool flag17 = flag16;
+						bool flag18 = flag17;
+						if (flag18)
+						{
+							extraCost += traversalCost;
+							bool isDiagnoal = fromDir.IsDiagnoal;
+							bool flag19 = isDiagnoal;
+							bool flag20 = flag19;
+							if (flag20)
+							{
+								this.tmpVec.Add((double)(-(double)((float)fromDir.Normali.X) / 2f), 0.0, (double)(-(double)((float)fromDir.Normali.Z) / 2f));
+								bool flag21 = this.collTester.IsColliding(this.blockAccessor, this.entityCollBox, this.tmpVec, false);
+								bool flag22 = flag21;
+								bool flag23 = flag22;
+								if (flag23)
+								{
+									return false;
+								}
+							}
+							this.tmpPos.Set(node.BlockPos.X, node.BlockPos.Y, node.BlockPos.Z);
+							Block block2 = this.blockAccessor.GetBlock(this.tmpPos, 2);
+							float traversalCost2 = block2.GetTraversalCost(this.tmpPos, EnumAICreatureType.Humanoid);
+							bool flag24 = traversalCost2 > 10000f;
+							bool flag25 = flag24;
+							bool flag26 = flag25;
+							if (flag26)
+							{
+								return false;
+							}
+							extraCost += traversalCost2;
+							return true;
+						}
+						else
+						{
+							this.tmpVec.Y -= 1.0;
+							bool flag27 = this.collTester.IsColliding(this.blockAccessor, this.entityCollBox, this.tmpVec, false);
+							bool flag28 = flag27;
+							bool flag29 = flag28;
+							if (flag29)
+							{
+								return false;
+							}
+							i++;
+							node.BlockPos.Y--;
+						}
+					}
+					flag6 = false;
+				}
+				else
+				{
+					this.tmpPos.Set(node.BlockPos.X, node.BlockPos.Y, node.BlockPos.Z);
+					Block block3 = this.blockAccessor.GetBlock(this.tmpPos);
+					bool flag30 = !block3.CanStep;
+					bool flag31 = flag30;
+					bool flag32 = flag31;
+					if (flag32)
+					{
+						flag6 = false;
+					}
+					else
+					{
+						float traversalCost3 = block3.GetTraversalCost(this.tmpPos, EnumAICreatureType.Humanoid);
+						bool flag33 = traversalCost3 > 10000f;
+						bool flag34 = flag33;
+						bool flag35 = flag34;
+						if (flag35)
+						{
+							flag6 = false;
+						}
+						else
+						{
+							extraCost += traversalCost3;
+							float num = 0f;
+							Cuboidf[] collisionBoxes2 = block3.GetCollisionBoxes(this.blockAccessor, this.tmpPos);
+							bool flag36 = collisionBoxes2 != null && collisionBoxes2.Length != 0;
+							bool flag37 = flag36;
+							bool flag38 = flag37;
+							if (flag38)
+							{
+								foreach (Cuboidf cuboidf in collisionBoxes2)
+								{
+									bool flag39 = cuboidf.Y2 > num;
+									bool flag40 = flag39;
+									bool flag41 = flag40;
+									if (flag41)
+									{
+										num = cuboidf.Y2;
+									}
+								}
+							}
+							this.tmpVec.Set((double)node.BlockPos.X + this.centerOffsetX, (double)node.BlockPos.Y + 1.2000000476837158 + (double)num - 1.0, (double)node.BlockPos.Z + this.centerOffsetZ);
+							bool flag42 = !this.collTester.IsColliding(this.blockAccessor, this.entityCollBox, this.tmpVec, false);
+							bool flag43 = flag42;
+							bool flag44 = flag43;
+							if (flag44)
+							{
+								bool flag45 = fromDir.IsDiagnoal && collisionBoxes2 != null && collisionBoxes2.Length != 0;
+								bool flag46 = flag45;
+								bool flag47 = flag46;
+								if (flag47)
+								{
+									this.tmpVec.Add((double)(-(double)((float)fromDir.Normali.X) / 2f), 0.0, (double)(-(double)((float)fromDir.Normali.Z) / 2f));
+									bool flag48 = this.collTester.IsColliding(this.blockAccessor, this.entityCollBox, this.tmpVec, false);
+									bool flag49 = flag48;
+									bool flag50 = flag49;
+									if (flag50)
+									{
+										return false;
+									}
+								}
+								node.BlockPos.Y += (int)(1f + num - 1f);
+								flag6 = true;
+							}
+							else
+							{
+								flag6 = false;
+							}
+						}
+					}
+				}
+			}
+			return flag6;
+		}
 
-            return neighbours;
-        }
+		// Token: 0x0600013A RID: 314 RVA: 0x00002CD1 File Offset: 0x00000ED1
+		public void SetEntityCollisionBox(Cuboidf collBox)
+		{
+			this.entityCollBox = collBox;
+		}
 
-        protected virtual bool traversable(VillagerPathNode node, BlockPos target)
-        {
-            if (target.Equals(node.BlockPos)) { return true; }
-            if (traversable(blockAccessor.GetBlock(node.BlockPos))
-                && traversable(blockAccessor.GetBlock(node.BlockPos.UpCopy())))
-            {
-                for (int fallHeightLeft = maxFallHeight; 0 <= fallHeightLeft; fallHeightLeft--)
-                {
-                    Block belowBlock = blockAccessor.GetBlock(node.BlockPos.DownCopy());
-                    if (canStep(belowBlock))
-                    {
-                        node.Init(target, isDoor(blockAccessor.GetBlock(node.BlockPos)));
-                        return true;
-                    }
-                    if (!traversable(belowBlock)) { return false; }
-                    ;
-                    node.BlockPos.Y--;
-                }
-                while (climbableCodes.Exists(code => blockAccessor.GetBlock(node.BlockPos).Code.Path.Contains(code)))
-                {
-                    Block belowBlock = blockAccessor.GetBlock(node.BlockPos.DownCopy());
-                    if (canStep(belowBlock))
-                    {
-                        node.Init(target, isDoor(blockAccessor.GetBlock(node.BlockPos)));
-                        return true;
-                    }
-                    node.BlockPos.Y--;
-                }
-            }
-            else
-            {
-                for (float stepHeightLeft = stepHeight; 1f < stepHeightLeft; stepHeightLeft--)
-                {
-                    node.BlockPos.Y++;
-                    if (canStep(blockAccessor.GetBlock(node.BlockPos.DownCopy())) && traversable(blockAccessor.GetBlock(node.BlockPos)) && traversable(blockAccessor.GetBlock(node.BlockPos.UpCopy())))
-                    {
-                        node.Init(target, isDoor(blockAccessor.GetBlock(node.BlockPos)));
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
+		// Token: 0x0600013B RID: 315 RVA: 0x0000B614 File Offset: 0x00009814
+		public void SetEntityCollisionBox(EntityAgent entity)
+		{
+			bool flag = entity != null && entity.CollisionBox != null;
+			bool flag2 = flag;
+			bool flag3 = flag2;
+			if (flag3)
+			{
+				this.entityCollBox = entity.CollisionBox;
+			}
+			else
+			{
+				this.entityCollBox = new Cuboidf(-0.4f, 0f, -0.4f, 0.4f, 1.8f, 0.4f);
+			}
+		}
 
-        protected virtual bool canStep(Block belowBlock)
-        {
-            return belowBlock.SideSolid[BlockFacing.UP.Index] || steppableCodes.Exists(belowBlock.Code.Path.Contains);
-        }
+		// Token: 0x0400009D RID: 157
+		public List<string> doorCodes;
 
-        private bool traversable(Block block)
-        {
-            return block.CollisionBoxes == null || block.CollisionBoxes.Length == 0 || traversableCodes.Exists(block.Code.Path.Contains);
-        }
+		// Token: 0x0400009E RID: 158
+		public List<string> climbableCodes;
 
-        private bool isDoor(Block block)
-        {
-            return doorCodes.Exists(block.Code.Path.Contains);
-        }
+		// Token: 0x0400009F RID: 159
+		public List<string> steppableCodes;
 
-        public BlockPos GetStartPos(Vec3d startPos)
-        {
-            var result = startPos.AsBlockPos;
-            var startBlock = blockAccessor.GetBlock(result);
-            if (traversable(startBlock))
-            {
-                return result;
-            }
+		// Token: 0x040000A0 RID: 160
+		public ICachingBlockAccessor blockAccessor;
 
-            if (getDecimalPart(startPos.Z) < 0.5 && traversable(blockAccessor.GetBlock(result.NorthCopy())))
-            {
-                return result.NorthCopy();
-            }
+		// Token: 0x040000A1 RID: 161
+		public const float stepHeight = 1.2f;
 
-            if (getDecimalPart(startPos.Z) > 0.5 && traversable(blockAccessor.GetBlock(result.SouthCopy())))
-            {
-                return result.SouthCopy();
-            }
+		// Token: 0x040000A2 RID: 162
+		public const int maxFallHeight = 5;
 
-            if (getDecimalPart(startPos.X) < 0.5 && traversable(blockAccessor.GetBlock(result.West())))
-            {
-                return result;
-            }
+		// Token: 0x040000A3 RID: 163
+		protected CollisionTester collTester;
 
-            if (getDecimalPart(startPos.X) > 0.5 && traversable(blockAccessor.GetBlock(result.East())))
-            {
-                return result;
-            }
+		// Token: 0x040000A4 RID: 164
+		protected Cuboidf entityCollBox = new Cuboidf(-0.4f, 0f, -0.4f, 0.4f, 1.8f, 0.4f);
 
-            if (getDecimalPart(startPos.Z) < 0.5 && traversable(blockAccessor.GetBlock(result.NorthCopy())))
-            {
-                return result.NorthCopy();
-            }
+		// Token: 0x040000A5 RID: 165
+		protected double centerOffsetX = 0.5;
 
-            if (getDecimalPart(startPos.Z) > 0.5 && traversable(blockAccessor.GetBlock(result.SouthCopy())))
-            {
-                return result.SouthCopy();
-            }
+		// Token: 0x040000A6 RID: 166
+		protected double centerOffsetZ = 0.5;
 
-            return startPos.AsBlockPos;
-        }
+		// Token: 0x040000A7 RID: 167
+		protected Vec3d tmpVec;
 
-        private double getDecimalPart(double number)
-        {
-            return number - Math.Truncate(number);
-        }
-    }
+		// Token: 0x040000A8 RID: 168
+		protected BlockPos tmpPos;
+
+		// Token: 0x040000A9 RID: 169
+		public List<string> traversableCodes;
+	}
 }

--- a/VSVillage/src/Entity/Pathfinding/VillagerPathNode.cs
+++ b/VSVillage/src/Entity/Pathfinding/VillagerPathNode.cs
@@ -1,73 +1,161 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Vintagestory.API.MathTools;
 using Vintagestory.Essentials;
 
 namespace VsVillage
 {
-    public class VillagerPathNode : IEquatable<VillagerPathNode>, IComparable<VillagerPathNode>
-    {
-        public VillagerPathNode Parent;
-        public BlockPos BlockPos;
-        public bool IsDoor = false;
-        public float Cost;
-        public PathNode ToPathNode() => new PathNode(BlockPos);
-        public Vec3d ToWaypoint() => new Vec3d(BlockPos.X + 0.5, BlockPos.Y, BlockPos.Z + 0.5);
+	// Token: 0x0200002F RID: 47
+	public class VillagerPathNode : IEquatable<VillagerPathNode>, IComparable<VillagerPathNode>
+	{
+		// Token: 0x06000141 RID: 321 RVA: 0x0000B714 File Offset: 0x00009914
+		public PathNode ToPathNode()
+		{
+			return new PathNode(this.BlockPos);
+		}
 
-        public VillagerPathNode(BlockPos blockPos, BlockPos target, bool isDoor)
-        {
-            BlockPos = blockPos;
-            Cost = blockPos.DistanceSqTo(target.X, target.Y, target.Z);
-            IsDoor = isDoor;
-        }
+		// Token: 0x06000142 RID: 322 RVA: 0x0000B734 File Offset: 0x00009934
+		public Vec3d ToWaypoint()
+		{
+			return new Vec3d((double)this.BlockPos.X + 0.5, (double)this.BlockPos.Y, (double)this.BlockPos.Z + 0.5);
+		}
 
-        public VillagerPathNode(VillagerPathNode parent, Cardinal cardinal)
-        {
-            Parent = parent;
-            BlockPos = parent.BlockPos.AddCopy(cardinal.Normali.X, cardinal.Normali.Y, cardinal.Normali.Z);
-        }
+		// Token: 0x06000143 RID: 323 RVA: 0x0000B784 File Offset: 0x00009984
+		public VillagerPathNode(BlockPos blockPos, BlockPos target, bool isDoor)
+		{
+			this.BlockPos = blockPos;
+			this.IsDoor = isDoor;
+			this.gCost = 0f;
+			this.hCost = (float)Math.Sqrt((double)blockPos.DistanceSqTo((double)target.X, (double)target.Y, (double)target.Z));
+			this.pathLength = 0;
+			this.Parent = null;
+		}
 
-        public void Init(BlockPos target, bool isDoor)
-        {
-            Cost = BlockPos.DistanceSqTo(target.X, target.Y, target.Z);
-            IsDoor = isDoor;
-        }
+		// Token: 0x06000144 RID: 324 RVA: 0x0000B7E8 File Offset: 0x000099E8
+		public VillagerPathNode(VillagerPathNode parent, Cardinal cardinal)
+		{
+			this.Parent = parent;
+			this.BlockPos = parent.BlockPos.AddCopy(cardinal.Normali.X, cardinal.Normali.Y, cardinal.Normali.Z);
+			this.pathLength = parent.pathLength + 1;
+			this.gCost = 0f;
+			this.hCost = 0f;
+			this.IsDoor = false;
+		}
 
-        public bool Equals(VillagerPathNode other)
-        {
-            return BlockPos.Equals(other?.BlockPos);
-        }
+		// Token: 0x06000145 RID: 325 RVA: 0x00002CFD File Offset: 0x00000EFD
+		public void Init(BlockPos target, bool isDoor)
+		{
+			this.hCost = (float)Math.Sqrt((double)this.BlockPos.DistanceSqTo((double)target.X, (double)target.Y, (double)target.Z));
+			this.IsDoor = isDoor;
+		}
 
-        public override bool Equals(object obj)
-        {
-            if (obj is VillagerPathNode other)
-            {
-                return Equals(other);
-            }
-            return false;
-        }
+		// Token: 0x06000146 RID: 326 RVA: 0x0000B864 File Offset: 0x00009A64
+		public bool Equals(VillagerPathNode other)
+		{
+			return this.BlockPos.Equals((other != null) ? other.BlockPos : null);
+		}
 
-        public override int GetHashCode()
-        {
-            return BlockPos.GetHashCode();
-        }
+		// Token: 0x06000147 RID: 327 RVA: 0x0000B890 File Offset: 0x00009A90
+		public override bool Equals(object obj)
+		{
+			VillagerPathNode villagerPathNode = obj as VillagerPathNode;
+			return villagerPathNode != null && this.Equals(villagerPathNode);
+		}
 
-        public List<VillagerPathNode> RetracePath()
-        {
-            var current = this;
-            var result = new List<VillagerPathNode>([current]);
-            while (current.Parent != null)
-            {
-                current = current.Parent;
-                result.Add(current);
-            }
-            result.Reverse();
-            return result;
-        }
+		// Token: 0x06000148 RID: 328 RVA: 0x0000B8B8 File Offset: 0x00009AB8
+		public override int GetHashCode()
+		{
+			return this.BlockPos.GetHashCode();
+		}
 
-        public int CompareTo(VillagerPathNode other)
-        {
-            return Cost.CompareTo(other.Cost);
-        }
-    }
+		// Token: 0x06000149 RID: 329 RVA: 0x0000B8D8 File Offset: 0x00009AD8
+		public List<VillagerPathNode> RetracePath()
+		{
+			List<VillagerPathNode> list = new List<VillagerPathNode>(this.pathLength + 1);
+			for (int i = 0; i <= this.pathLength; i++)
+			{
+				list.Add(null);
+			}
+			VillagerPathNode villagerPathNode = this;
+			for (int j = this.pathLength; j >= 0; j--)
+			{
+				list[j] = villagerPathNode;
+				villagerPathNode = villagerPathNode.Parent;
+			}
+			return list;
+		}
+
+		// Token: 0x0600014A RID: 330 RVA: 0x0000B950 File Offset: 0x00009B50
+		public int CompareTo(VillagerPathNode other)
+		{
+			int num = this.fCost.CompareTo(other.fCost);
+			bool flag = num == 0;
+			bool flag2 = flag;
+			if (flag2)
+			{
+				num = this.hCost.CompareTo(other.hCost);
+			}
+			bool flag3 = num == 0;
+			bool flag4 = flag3;
+			if (flag4)
+			{
+				num = this.BlockPos.GetHashCode().CompareTo(other.BlockPos.GetHashCode());
+			}
+			return num;
+		}
+
+		// Token: 0x0600014B RID: 331 RVA: 0x0000B9C8 File Offset: 0x00009BC8
+		public float distanceTo(VillagerPathNode other)
+		{
+			int num = Math.Abs(this.BlockPos.X - other.BlockPos.X);
+			int num2 = Math.Abs(this.BlockPos.Y - other.BlockPos.Y);
+			int num3 = Math.Abs(this.BlockPos.Z - other.BlockPos.Z);
+			int num4 = Math.Min(num, num3);
+			int num5 = Math.Max(num, num3);
+			return (float)(1.414 * (double)num4 + (double)(num5 - num4) + (double)num2);
+		}
+
+		// Token: 0x0600014C RID: 332 RVA: 0x0000BA5C File Offset: 0x00009C5C
+		public void SetGCostFromParent(VillagerPathNode parent, float extraCost)
+		{
+			bool flag = parent != null;
+			bool flag2 = flag;
+			if (flag2)
+			{
+				this.gCost = parent.gCost + parent.distanceTo(this) + extraCost;
+			}
+			else
+			{
+				this.gCost = extraCost;
+			}
+		}
+
+		// Token: 0x17000024 RID: 36
+		// (get) Token: 0x0600014D RID: 333 RVA: 0x0000BA98 File Offset: 0x00009C98
+		public float fCost
+		{
+			get
+			{
+				return this.gCost + this.hCost;
+			}
+		}
+
+		// Token: 0x040000AC RID: 172
+		public VillagerPathNode Parent;
+
+		// Token: 0x040000AD RID: 173
+		public BlockPos BlockPos;
+
+		// Token: 0x040000AE RID: 174
+		public bool IsDoor;
+
+		// Token: 0x040000AF RID: 175
+		public float gCost;
+
+		// Token: 0x040000B0 RID: 176
+		public float hCost;
+
+		// Token: 0x040000B1 RID: 177
+		public int pathLength;
+	}
 }

--- a/VSVillage/src/Entity/Pathfinding/VillagerPathfind.cs
+++ b/VSVillage/src/Entity/Pathfinding/VillagerPathfind.cs
@@ -1,49 +1,60 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
-using Vintagestory.Essentials;
 
 namespace VsVillage
 {
-    public class VillagerPathfind
-    {
-        private VillagerAStarNew villagerAStar;
-        private WaypointAStar waypointAStar;
+	// Token: 0x0200002E RID: 46
+	public class VillagerPathfind
+	{
+		// Token: 0x0600013C RID: 316 RVA: 0x0000B674 File Offset: 0x00009874
+		public VillagerPathfind(ICoreServerAPI sapi)
+		{
+			ICachingBlockAccessor cachingBlockAccessor = sapi.World.GetCachingBlockAccessor(true, true);
+			this.villagerAStar = new VillagerAStarNew(cachingBlockAccessor);
+			this.waypointAStar = new WaypointAStar(cachingBlockAccessor);
+		}
 
-        public VillagerPathfind(ICoreServerAPI sapi)
-        {
-            var blockAccessor = sapi.World.GetCachingBlockAccessor(true, true);
-            villagerAStar = new VillagerAStarNew(blockAccessor);
-            waypointAStar = new WaypointAStar(blockAccessor);
-        }
+		// Token: 0x0600013D RID: 317 RVA: 0x00002CDB File Offset: 0x00000EDB
+		public BlockPos GetStartPos(Vec3d startPos)
+		{
+			return this.villagerAStar.GetStartPos(startPos);
+		}
 
-        public BlockPos GetStartPos(Vec3d startPos)
-        {
-            return villagerAStar.GetStartPos(startPos);
-        }
+		// Token: 0x0600013E RID: 318 RVA: 0x00002CE9 File Offset: 0x00000EE9
+		public List<VillagerPathNode> FindPath(BlockPos start, BlockPos end, Village village)
+		{
+			return this.villagerAStar.FindPath(start, end, 5000);
+		}
 
-        public List<VillagerPathNode> FindPath(BlockPos start, BlockPos end, Village village)
-        {
-            var path = villagerAStar.FindPath(start, end, 5000);
-            return path;
-        }
+		// Token: 0x0600013F RID: 319 RVA: 0x0000B6B0 File Offset: 0x000098B0
+		public List<Vec3d> FindPathAsWaypoints(BlockPos start, BlockPos end, Village village)
+		{
+			List<VillagerPathNode> list = this.FindPath(start, end, village);
+			if (list != null)
+			{
+				return this.ToWaypoints(list);
+			}
+			return null;
+		}
 
-        public List<Vec3d> FindPathAsWaypoints(BlockPos start, BlockPos end, Village village)
-        {
-            List<VillagerPathNode> nodes = FindPath(start, end, village);
-            return nodes == null ? null : ToWaypoints(nodes);
-        }
-        public List<Vec3d> ToWaypoints(List<VillagerPathNode> path)
-        {
-            List<Vec3d> waypoints = new List<Vec3d>(path.Count + 1);
-            for (int i = 1; i < path.Count; i++)
-            {
-                waypoints.Add(path[i].ToWaypoint());
-            }
+		// Token: 0x06000140 RID: 320 RVA: 0x0000B6D4 File Offset: 0x000098D4
+		public List<Vec3d> ToWaypoints(List<VillagerPathNode> path)
+		{
+			List<Vec3d> list = new List<Vec3d>(path.Count + 1);
+			for (int i = 1; i < path.Count; i++)
+			{
+				list.Add(path[i].ToWaypoint());
+			}
+			return list;
+		}
 
-            return waypoints;
-        }
+		// Token: 0x040000AA RID: 170
+		private VillagerAStarNew villagerAStar;
 
-    }
+		// Token: 0x040000AB RID: 171
+		private WaypointAStar waypointAStar;
+	}
 }

--- a/VSVillage/src/Systems/VsVillage.cs
+++ b/VSVillage/src/Systems/VsVillage.cs
@@ -1,48 +1,46 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Vintagestory.API.Common;
-using Vintagestory.API.Server;
 using Vintagestory.GameContent;
 
 namespace VsVillage
 {
-    public class VsVillage : ModSystem
-    {
-        public override void Start(ICoreAPI api)
-        {
-            base.Start(api);
-
-            api.RegisterEntityBehaviorClass("Villager", typeof(EntityBehaviorVillager));
-            api.RegisterEntityBehaviorClass("replacewithentity", typeof(EntityBehaviorReplaceWithEntity));
-
-            api.RegisterItemClass("ItemVillagerGear", typeof(ItemVillagerGear));
-            api.RegisterItemClass("ItemVillagerHorn", typeof(ItemVillagerHorn));
-
-            api.RegisterBlockEntityClass("VillagerBed", typeof(BlockEntityVillagerBed));
-            api.RegisterBlockEntityClass("VillagerWorkstation", typeof(BlockEntityVillagerWorkstation));
-            api.RegisterBlockEntityClass("VillagerWaypoint", typeof(BlockEntityVillagerWaypoint));
-            api.RegisterBlockEntityClass("VillagerBrazier", typeof(BlockEntityVillagerBrazier));
-
-            api.RegisterBlockClass("MayorWorkstation", typeof(BlockMayorWorkstation));
-
-            AiTaskRegistry.Register<AiTaskVillagerMeleeAttack>("villagermeleeattack");
-            AiTaskRegistry.Register<AiTaskVillagerSeekEntity>("villagerseekentity");
-            AiTaskRegistry.Register<AiTaskVillagerSleep>("villagersleep");
-            AiTaskRegistry.Register<AiTaskVillagerSocialize>("villagersocialize");
-            AiTaskRegistry.Register<AiTaskVillagerGotoWork>("villagergotowork");
-            AiTaskRegistry.Register<AiTaskVillagerGotoGatherspot>("villagergotogather");
-            AiTaskRegistry.Register<AiTraskVillagerFillTrough>("villagerfilltrough");
-            AiTaskRegistry.Register<AiTraskVillagerCultivateCrops>("villagercultivatecrops");
-            AiTaskRegistry.Register<AiTraskVillagerFlipWeapon>("villagerflipweapon");
-            AiTaskRegistry.Register<AiTaskStayCloseToEmployer>("villagerstayclose");
-            AiTaskRegistry.Register<AiTaskHealWounded>("villagerhealwounded");
-            AiTaskRegistry.Register<AiTaskVillagerRangedAttack>("villagerrangedattack");
-
-            ActivityModSystem.ActionTypes.TryAdd(GotoPointOfInterestAction.ActionType, typeof(GotoPointOfInterestAction));
-            ActivityModSystem.ActionTypes.TryAdd(SleepAction.ActionType, typeof(SleepAction));
-            ActivityModSystem.ActionTypes.TryAdd(ToggleBrazierFireAction.ActionType, typeof(ToggleBrazierFireAction));
-
-            ActivityModSystem.ConditionTypes.TryAdd(CloseToPointOfInterestCondition.ConditionType, typeof(CloseToPointOfInterestCondition));
-            ActivityModSystem.ConditionTypes.TryAdd(CooldownCondition.ConditionType, typeof(CooldownCondition));
-        }
-    }
+	// Token: 0x02000051 RID: 81
+	public class VsVillage : ModSystem
+	{
+		// Token: 0x060001FB RID: 507 RVA: 0x0001006C File Offset: 0x0000E26C
+		public override void Start(ICoreAPI api)
+		{
+			base.Start(api);
+			api.RegisterEntityBehaviorClass("Villager", typeof(EntityBehaviorVillager));
+			api.RegisterEntityBehaviorClass("replacewithentity", typeof(EntityBehaviorReplaceWithEntity));
+			api.RegisterItemClass("ItemVillagerGear", typeof(ItemVillagerGear));
+			api.RegisterItemClass("ItemVillagerHorn", typeof(ItemVillagerHorn));
+			api.RegisterBlockEntityClass("VillagerBed", typeof(BlockEntityVillagerBed));
+			api.RegisterBlockEntityClass("VillagerWorkstation", typeof(BlockEntityVillagerWorkstation));
+			api.RegisterBlockEntityClass("VillagerWaypoint", typeof(BlockEntityVillagerWaypoint));
+			api.RegisterBlockEntityClass("VillagerBrazier", typeof(BlockEntityVillagerBrazier));
+			api.RegisterBlockClass("MayorWorkstation", typeof(BlockMayorWorkstation));
+			AiTaskRegistry.Register<AiTaskVillagerMeleeAttack>("villagermeleeattack");
+			AiTaskRegistry.Register<AiTaskVillagerSeekEntity>("villagerseekentity");
+			AiTaskRegistry.Register<AiTaskVillagerSleep>("villagersleep");
+			AiTaskRegistry.Register<AiTaskVillagerSocialize>("villagersocialize");
+			AiTaskRegistry.Register<AiTaskVillagerGotoWork>("villagergotowork");
+			AiTaskRegistry.Register<AiTaskVillagerGotoGatherspot>("villagergotogather");
+			AiTaskRegistry.Register<AiTaskVillagerFillTrough>("villagerfilltrough");
+			AiTaskRegistry.Register<AiTaskVillagerCultivateCrops>("villagercultivatecrops");
+			AiTaskRegistry.Register<AiTaskVillagerFlipWeapon>("villagerflipweapon");
+			AiTaskRegistry.Register<AiTaskStayCloseToEmployer>("villagerstayclose");
+			AiTaskRegistry.Register<AiTaskHealWounded>("villagerhealwounded");
+			AiTaskRegistry.Register<AiTaskVillagerRangedAttack>("villagerrangedattack");
+			AiTaskRegistry.Register<AiTaskVillagerWander>("villagerwander");
+			ActivityModSystem.ActionTypes.TryAdd("GotoPointOfInterest", typeof(GotoPointOfInterestAction));
+			ActivityModSystem.ActionTypes.TryAdd("Sleep", typeof(SleepAction));
+			ActivityModSystem.ActionTypes.TryAdd("ToggleBrazierFire", typeof(ToggleBrazierFireAction));
+			ActivityModSystem.ConditionTypes.TryAdd("CloseToPointOfInterest", typeof(CloseToPointOfInterestCondition));
+			ActivityModSystem.ConditionTypes.TryAdd("CooldownCondition", typeof(CooldownCondition));
+			ActivityModSystem.ActionTypes.TryAdd("CultivateCrops", typeof(CultivateCropsAction));
+			ActivityModSystem.ActionTypes.TryAdd("FillTrough", typeof(FillTroughAction));
+		}
+	}
 }

--- a/VSVillage/src/Systems/WorldGen/VillageGrid.cs
+++ b/VSVillage/src/Systems/WorldGen/VillageGrid.cs
@@ -45,12 +45,14 @@ namespace VsVillage
             VillageType = type;
             foreach (var group in type.StructureGroups)
             {
-                if(group.MatchingStructures.Count == 0){
+                if (group.MatchingStructures.Count == 0)
+                {
                     api.Logger.Error("Could not find any matching structures for group {0}!", group.Code);
                     continue;
                 }
-                int amount = rand.NextInt(group.MaxStructuresPerVillage + 1 - group.MinStructuresPerVillage) + group.MinStructuresPerVillage;
-                for (int i = 0; i < amount; i++)
+                int range = Math.Max(1, group.MaxStructuresPerVillage + 1 - group.MinStructuresPerVillage);
+                int num = rand.NextInt(range) + group.MinStructuresPerVillage;
+                for (int i = 0; i < num; i++)
                 {
                     tryAddStructure(group.MatchingStructures[rand.NextInt(group.MatchingStructures.Count)], rand);
                 }
@@ -168,68 +170,77 @@ namespace VsVillage
         //always go from biggest to smallest structure, otherwise this might break
         public bool tryAddStructure(WorldGenVillageStructure structure, LCGRandom random)
         {
-            int orientation = random.NextInt(4);
+            int num = random.NextInt(4);
             switch (structure.Size)
             {
-                case EnumVillageStructureSize.LARGE:
-                    if (capacity < 16) { return false; }
-                    else
+                case EnumVillageStructureSize.SMALL:
                     {
-                        var free = new List<Vec2i>();
-                        for (int i = 0; i < width / 8; i++)
+                        if (this.capacity < 1)
                         {
-                            for (int k = 0; k < height / 8; k++)
+                            return false;
+                        }
+                        List<Vec2i> list = new List<Vec2i>();
+                        for (int i = 0; i < this.width / 2; i++)
+                        {
+                            for (int j = 0; j < this.height / 2; j++)
                             {
-                                if (BigSlotAvailable(i, k))
+                                if (this.SmallSlotAvailable(i, j))
                                 {
-                                    free.Add(new Vec2i(i, k));
+                                    list.Add(new Vec2i(i, j));
                                 }
                             }
                         }
-                        var xy = free[random.NextInt(free.Count)];
-                        AddBigStructure(structure, xy.X, xy.Y, orientation);
+                        if (list.Count == 0) return false;
+                        Vec2i vec2i = list[random.NextInt(list.Count)];
+                        this.AddSmallStructure(structure, vec2i.X, vec2i.Y, num);
                         return true;
                     }
                 case EnumVillageStructureSize.MEDIUM:
-                    if (capacity < 4) { return false; }
-                    else
                     {
-                        var free = new List<Vec2i>();
-                        for (int i = 0; i < width / 4; i++)
+                        if (this.capacity < 4)
                         {
-                            for (int k = 0; k < height / 4; k++)
+                            return false;
+                        }
+                        List<Vec2i> list2 = new List<Vec2i>();
+                        for (int k = 0; k < this.width / 4; k++)
+                        {
+                            for (int l = 0; l < this.height / 4; l++)
                             {
-                                if (MediumSlotAvailable(i, k))
+                                if (this.MediumSlotAvailable(k, l))
                                 {
-                                    free.Add(new Vec2i(i, k));
+                                    list2.Add(new Vec2i(k, l));
                                 }
                             }
                         }
-                        var xy = free[random.NextInt(free.Count)];
-                        AddMediumStructure(structure, xy.X, xy.Y, orientation);
+                        if (list2.Count == 0) return false;
+                        Vec2i vec2i2 = list2[random.NextInt(list2.Count)];
+                        this.AddMediumStructure(structure, vec2i2.X, vec2i2.Y, num);
                         return true;
                     }
-                case EnumVillageStructureSize.SMALL:
-                    if (capacity < 1) { return false; }
-                    else
+                case EnumVillageStructureSize.LARGE:
                     {
-                        var free = new List<Vec2i>();
-                        for (int i = 0; i < width / 2; i++)
+                        if (this.capacity < 16)
                         {
-                            for (int k = 0; k < height / 2; k++)
+                            return false;
+                        }
+                        List<Vec2i> list3 = new List<Vec2i>();
+                        for (int m = 0; m < this.width / 8; m++)
+                        {
+                            for (int n = 0; n < this.height / 8; n++)
                             {
-                                if (SmallSlotAvailable(i, k))
+                                if (this.BigSlotAvailable(m, n))
                                 {
-                                    free.Add(new Vec2i(i, k));
+                                    list3.Add(new Vec2i(m, n));
                                 }
                             }
                         }
-                        var xy = free[random.NextInt(free.Count)];
-                        AddSmallStructure(structure, xy.X, xy.Y, orientation);
+                        if (list3.Count == 0) return false;
+                        Vec2i vec2i3 = list3[random.NextInt(list3.Count)];
+                        this.AddBigStructure(structure, vec2i3.X, vec2i3.Y, num);
                         return true;
                     }
-                default: return false;
-
+                default:
+                    return false;
             }
         }
 


### PR DESCRIPTION
Taken from my working notes before my power problem happened.

## Confirmed Working Systems

### ✅ Door & Gate Handling
- Uses `block.Code.Path.Contains("door")` / `Contains("gate")` string matching — **do not replace with `HasBehavior<BlockBehaviorDoor>` or `CollisionTester` approaches**, these caused regressions
- Opens via `block.Activate()` with `TreeAttribute { "opened": true }`
- Two-block-tall doors: check both Y and Y+1
- Closing uses `RegisterCallback` with 2-second delay after passing
- **CRITICAL**: Use `BlockPos.Copy()` in the callback lambda — without it the reference changes and closes the wrong door (`[TAG: DOOR-COPY-FIX]`)
- Gates require waiting for animation before passage

### ✅ Custom A* Pathfinding (VillagerAStarNew)
- Proper gCost + hCost (not just heuristic distance)
- String-matching for block traversal (doors/gates/fences) — simpler and more stable than `GetTraversalCost()` / `CollisionTester` which caused widespread "no path found" regressions
- Y-level tolerance ±1 block so villagers can path to targets at slightly different elevations
- Nodes flagged with `IsDoor = true` for door open/close logic during traversal
- `SetEntityCollisionBox(entity)` must be called before pathfinding

### ✅ Time Scheduling
- `IntervalUtil.matchesCurrentTime()` is **broken for overnight ranges** (e.g. 21.5–6.0) — completely bypassed with manual time checking
- Search for `[TAG: INTERVALUTIL-REMOVED]` in codebase

### ✅ Movement
- `WalkVector` must be **explicitly cleared** after task completion — not clearing it causes villagers to glide/float indefinitely (`[TAG: WALKVECTOR-FIX]`)
- `ServerPos.Yaw` set only **after movement stops**, not during — setting it during movement causes backwards walking
- Movement speed must be set in both code and entity JSON

### ✅ Farmland Traversal
- Farmers approach farmland from **adjacent positions**, not standing on it — farmland collision box height traps villagers
- Farmland treated as non-traversable in pathfinder where appropriate
- Primitive Survival mod adds `furrowedland` blocks — treated same as farmland

### ✅ OnHurt Crash Fix
- Vanilla `EntityBehaviorActivityDriven.OnHurt` has null-reference bugs
- Fix: `EntityBehaviorSafeOnHurt` intercepts ALL damage sources before vanilla code runs
- Checks null at behavior, ActivitySystem, and ActiveActivitiesBySlot levels
- Registered in `VsVillageMod.cs` via `RegisterEntityBehaviorClass`
- Added to villager entity JSON behaviors section
- **Must cover all damage sources** — not just herbalist healing

### ✅ Herbalist Healing
- Interaction range: **3 blocks** (was 2, too restrictive)
- Healing via `ReceiveDamage()` with negative damage value

### ✅ Task Cooldowns
- Cooldowns must be set in entity JSON or tasks silently fail / won't repeat
- Example: `"mincooldown": 60, "maxcooldown": 120` in task config

---

## Known Issues / Tabled Work

### 🔲 Profession-Specific Patrol System (Planned, Not Built)
Intended to replace generic wander behavior:
- **Farmers**: patrol between farmland blocks within configurable radius
- **Shepherds**: patrol between domesticated animals (detected by generation attributes or known animal type list)
- Fallback: generic wander if no valid targets found
- JSON-configurable radius and target types
- Goal: make movement look purposeful, keep villagers near their work area


### 🔲 Cultivation Task Frequency
- Tasks need cooldown + frequency tuning in entity JSON to fire repeatedly
- Groundwork is there, needs config validation


1. **Never add `CollisionTester` or `GetTraversalCost()` to VillagerAStarNew** — caused widespread "no path found" regressions across all tasks. String matching works and is stable.

2. **Never set `ServerPos.Yaw` during movement** — causes backwards walking. Only set it after `targetReached = true`.

3. **Always clear `WalkVector` in `FinishExecute`** — not doing so causes floating/gliding after task completion.

4. **Do not trust `IntervalUtil.matchesCurrentTime()`** — broken for overnight ranges. Use manual time checking.

5. **Always use `BlockPos.Copy()` in door-closing callbacks** — lambda captures reference, not value.

6. **`ContinueExecute` returning `true` in a fire-and-exit task blocks all other tasks** — door openers, one-shot interactions, etc. must return `false` immediately.

7. **Base classes compile before derived classes in dnSpy** when adding new fields — get the order wrong and you'll get cryptic errors.

8. **JSON cooldowns are load-bearing** — missing cooldown config causes tasks to block each other or never repeat.


Tagged changes in codebase use this pattern: `[TAG: TAGNAME]`

Known tags:
- `[TAG: DOOR-COPY-FIX]` — BlockPos.Copy() in door close callback
- `[TAG: WALKVECTOR-FIX]` — WalkVector cleared after task
- `[TAG: INTERVALUTIL-REMOVED]` — Manual time checking replacing broken vanilla util
- `[TAG: COLLISION-HEIGHT-CHECK]` — Block height checking in traversal (check if still present after regressions)
- `[TAG: EXPLICIT-BLOCKERS]` — Fence/wall blocked in pathfinder